### PR TITLE
Add redirection to bitmap/url in 2htdp/image.

### DIFF
--- a/htdp-lib/2htdp/private/image-more.rkt
+++ b/htdp-lib/2htdp/private/image-more.rkt
@@ -1411,7 +1411,7 @@
   (rotate
    0
    (call/input-url (string->url string)
-                   get-pure-port
+                   (lambda (u [h '()]) (get-pure-port u h #:redirections 5))          
                    (λ (port)
                      (make-object bitmap% port 'unknown/alpha #f #t)))))
                       


### PR DESCRIPTION
Needed redirection, but bitmap/url did not support it. Added support for it following a discussion with soegaard on #racket.