### PR TITLE
Spelling corrections for doc

### DIFF
--- a/htdp-lib/lang/private/advanced-funs.rkt
+++ b/htdp-lib/lang/private/advanced-funs.rkt
@@ -239,7 +239,7 @@
    ("Hash Tables"
     @defproc[((advanced-make-hash make-hash)) (hash X Y)]{
     Constructs a mutable hash table from an optional list of mappings that
-    uses equal? for comparisions.
+    uses equal? for comparisons.
     @interaction[#:eval (asl)
       (make-hash)
       (make-hash '((b 69) (e 61) (i 999)))
@@ -247,7 +247,7 @@
     } 
     @defproc[((advanced-make-hasheq make-hasheq)) (hash X Y)]{
     Constructs a mutable hash table from an optional list of mappings that
-    uses eq? for comparisions.
+    uses eq? for comparisons.
     @interaction[#:eval (asl)
       (make-hasheq)
       (make-hasheq '((b 69) (e 61) (i 999)))
@@ -255,7 +255,7 @@
     } 
     @defproc[((advanced-make-hasheqv make-hasheqv)) (hash X Y)]{
     Constructs a mutable hash table from an optional list of mappings that
-    uses eqv? for comparisions.
+    uses eqv? for comparisons.
     @interaction[#:eval (asl)
       (make-hasheqv)
       (make-hasheqv '((b 69) (e 61) (i 999)))
@@ -263,7 +263,7 @@
     } 
     @defproc[((advanced-make-immutable-hash make-immutable-hash)) (hash X Y)]{
     Constructs an immutable hash table from an optional list of mappings
-    that uses equal? for comparisions.
+    that uses equal? for comparisons.
     @interaction[#:eval (asl)
       (make-immutable-hash)
       (make-immutable-hash '((b 69) (e 61) (i 999)))
@@ -271,7 +271,7 @@
     } 
     @defproc[((advanced-make-immutable-hasheq make-immutable-hasheq)) (hash X Y)]{
     Constructs an immutable hash table from an optional list of mappings
-    that uses eq? for comparisions.
+    that uses eq? for comparisons.
     @interaction[#:eval (asl)
       (make-immutable-hasheq)
       (make-immutable-hasheq '((b 69) (e 61) (i 999)))
@@ -279,7 +279,7 @@
     } 
     @defproc[((advanced-make-immutable-hasheqv make-immutable-hasheqv)) (hash X Y)]{
     Constructs an immutable hash table from an optional list of mappings
-    that uses eqv? for comparisions.
+    that uses eqv? for comparisons.
     @interaction[#:eval (asl)
       (make-immutable-hasheqv)
       (make-immutable-hasheqv '((b 69) (e 61) (i 999)))
@@ -405,27 +405,27 @@
 
 @defproc[((advanced-make-hash make-hash) (case-> (-> (hash X Y)) ((listof (list X Y)) -> (hash X Y))]{
  Constructs a mutable hash table from an optional list of mappings that
- uses equal? for comparisions.} 
+ uses equal? for comparisons.}
 
 @defproc[((advanced-make-hasheq make-hasheq) (case-> (-> (hash X Y)) ((listof (list X Y)) -> (hash X Y))]{
  Constructs a mutable hash table from an optional list of mappings that
- uses eq? for comparisions.} 
+ uses eq? for comparisons.}
 
 @defproc[((advanced-make-hasheqv make-hasheqv) (case-> (-> (hash X Y)) ((listof (list X Y)) -> (hash X Y))]{
  Constructs a mutable hash table from an optional list of mappings that
- uses eqv? for comparisions.} 
+ uses eqv? for comparisons.}
 
 @defproc[((advanced-make-immutable-hash make-immutable-hash) (case-> (-> (hash X Y)) ((listof (list X Y)) -> (hash X Y))]{
  Constructs an immutable hash table from an optional list of mappings that
- uses equal? for comparisions.} 
+ uses equal? for comparisons.}
 
 @defproc[((advanced-make-immutable-hasheq make-immutable-hasheq) (case-> (-> (hash X Y)) ((listof (list X Y)) -> (hash X Y))]{
  Constructs an immutable hash table from an optional list of mappings that
- uses eq? for comparisions.} 
+ uses eq? for comparisons.}
 
 @defproc[((advanced-make-immutable-hasheqv make-immutable-hasheqv) (case-> (-> (hash X Y)) ((listof (list X Y)) -> (hash X Y))]{
  Constructs an immutable hash table from an optional list of mappings that
- uses eqv? for comparisions.} 
+ uses eqv? for comparisons.}
 
 @defproc[(hash-ref (case-> ((hash X Y) X -> Y) ((hash X Y) X Y -> Y) ((hash X Y) X (-> Y) -> Y))]{
  Extracts the value associated with a key from a hash table; the three

--- a/htdp-lib/lang/private/beginner-funs.rkt
+++ b/htdp-lib/lang/private/beginner-funs.rkt
@@ -300,7 +300,7 @@
                                        }
   @defproc[(complex? [x any/c]) boolean?]{
                                           Determines whether some value is complex. 
-                                          @interaction[#:eval (bsl) (real? 1-2i)]
+                                          @interaction[#:eval (bsl) (complex? 1-2i)]
                                           }
   
   ;; common utilities 

--- a/htdp-lib/lang/private/beginner-funs.rkt
+++ b/htdp-lib/lang/private/beginner-funs.rkt
@@ -149,11 +149,11 @@
                                                                         @interaction[#:eval (bsl) (/ 12 2) (/ 12 2 3)]
                                                                         }
   @defproc[(max [x real][y real] ...) real]{
-                                            Determines the largest number---aka, the @index["maximum"]{maxiumum}. 
+                                            Determines the largest number---aka, the @index["maximum"]{maximum}.
                                                                                      @interaction[#:eval (bsl) (max 3 2 8 7 2 9 0)]
                                                                                      }
   @defproc[(min [x real][y real] ...) real]{
-                                            Determines the smallest number---aka, the @index["minimum"]{miniumum}. 
+                                            Determines the smallest number---aka, the @index["minimum"]{minimum}.
                                                                                       @interaction[#:eval (bsl) (min 3 2 8 7 2 9 0)]
                                                                                       }
   @defproc[(quotient [x integer][y integer]) integer]{
@@ -305,7 +305,7 @@
   
   ;; common utilities 
   @defproc[(add1 [x number]) number]{
-                                     Incrementes the given number.
+                                     Increments the given number.
                                      @interaction[#:eval (bsl) (add1 2)]
                                      }
   @defproc[(sub1 [x number]) number]{
@@ -317,7 +317,7 @@
                                                      @interaction[#:eval (bsl) (lcm 6 12 8)]
                                                      }
   @defproc[(gcd [x integer][y integer] ...) integer]{
-                                                     Determines the greatest common divisior of two integers (exact or inexact). 
+                                                     Determines the greatest common divisor of two integers (exact or inexact).
                                                      @interaction[#:eval (bsl) (gcd 6 12 8)]
                                                      }
   @defproc[(numerator [x rational?]) integer]{
@@ -325,7 +325,7 @@
                                               @interaction[#:eval (bsl) (numerator 2/3)]
                                               }
   @defproc[(denominator [x rational?]) integer]{
-                                                Computees the denominator of a rational.
+                                                Computes the denominator of a rational.
                                                 @interaction[#:eval (bsl) (denominator 2/3)]
                                                 }
   @defproc[(floor [x real]) integer]{
@@ -388,7 +388,7 @@
                                                @interaction[#:eval (bsl) (number->string 42)]
                                                }
   @defproc[(integer->char [x exact-integer?]) char]{
-                                                    Lookups the character that corresponds to the given exact integer in the ASCII table (if any). 
+                                                    Looks up the character that corresponds to the given exact integer in the ASCII table (if any).
                                                     @interaction[#:eval (bsl) (integer->char 42)]
                                                     }
   @defproc[((beginner-random random) [x natural]) natural]{
@@ -656,7 +656,7 @@
                                                            @interaction[#:eval (bsl) (char=? #\b #\a)]
                                                            }
   @defproc[(char<? [x char][d char][e char] ...) boolean?]{
-                                                           Determines whether the characterc are ordered in a strictly increasing manner. 
+                                                           Determines whether the characters are ordered in a strictly increasing manner.
                                                            @interaction[#:eval (bsl) (char<? #\a #\b #\c)]
                                                            }
   @defproc[(char>? [c char][d char][e char] ...) boolean?]{
@@ -664,7 +664,7 @@
                                                            @interaction[#:eval (bsl) (char>? #\A #\z #\a)]
                                                            }
   @defproc[(char<=? [c char][d char][e char] ...) boolean?]{
-                                                            Determines whether the characterc are ordered in a strictly increasing manner. 
+                                                            Determines whether the characters are ordered in a strictly increasing manner.
                                                             @interaction[#:eval (bsl) (char<=? #\a #\a #\b)]
                                                             }
   @defproc[(char>=? [c char][d char][e char] ...) boolean?]{
@@ -677,7 +677,7 @@
                                                               @interaction[#:eval (bsl) (char-ci=? #\b #\B)]
                                                               }
   @defproc[(char-ci<? [c char][d char][e char] ...) boolean?]{
-                                                              Determines whether the characterc are ordered in a strictly increasing and case-insensitive manner. 
+                                                              Determines whether the characters are ordered in a strictly increasing and case-insensitive manner.
                                                               @interaction[#:eval (bsl) (char-ci<? #\B #\c) (char<? #\b #\B)]
                                                               }
   @defproc[(char-ci>? [c char][d char][e char] ...) boolean?]{
@@ -685,7 +685,7 @@
                                                               @interaction[#:eval (bsl) (char-ci>? #\b #\B) (char>? #\b #\B)]
                                                               }
   @defproc[(char-ci<=? [c char][d char][e char] ...) boolean?]{
-                                                               Determines whether the characterc are ordered in an increasing and case-insensitive manner. 
+                                                               Determines whether the characters are ordered in an increasing and case-insensitive manner.
                                                                @interaction[#:eval (bsl) (char-ci<=? #\b #\B) (char<=? #\b #\B)]
                                                                }
   @defproc[(char-ci>=? [c char][d char][e char] ...) boolean?]{
@@ -721,7 +721,7 @@
                                           @interaction[#:eval (bsl) (char-downcase #\T)]
                                           }
   @defproc[(char->integer [c char]) integer]{
-                                             Lookups the number that corresponds to the given character in the ASCII table (if any). 
+                                             Looks up the number that corresponds to the given character in the ASCII table (if any).
                                              @interaction[#:eval (bsl) (char->integer #\a) (char->integer #\z)]
                                              })
  

--- a/htdp-lib/lang/private/provide-and-scribble.rkt
+++ b/htdp-lib/lang/private/provide-and-scribble.rkt
@@ -155,8 +155,8 @@ tests to run:
                          ;; Section  = [Listof (cons Identifier Doc)]
                          ;; Sections = [Listof (list Title Section)]
                          (provide 
-                          ;; Identfier ... *-> Sections 
-                          ;; retrieve the document without the specified identfiers
+                          ;; Identifier ... *-> Sections
+                          ;; retrieve the document without the specified identifiers
                           docs
                           
                           ;; Sections String -> [Listof ScribbleBox]

--- a/htdp-lib/lang/private/teach.rkt
+++ b/htdp-lib/lang/private/teach.rkt
@@ -463,7 +463,7 @@
         "a keyword"
         (something-else stx)))
   
-  (define (make-name-inventer)
+  (define (make-name-inventor)
     ;; Normally we'd use (make-syntax-introducer) because gensyming makes
     ;;  identifiers that play badly with exporting. But we don't have
     ;;  to worry about exporting in the teaching languages, while we do
@@ -475,7 +475,7 @@
   
   (define (wrap-func-definitions first-order? kinds names argcs k)
     (if first-order?
-        (let ([name2s (map (make-name-inventer) names)])
+        (let ([name2s (map (make-name-inventor) names)])
           (values (quasisyntax
                    (begin
                      #,@(map

--- a/htdp-lib/lang/private/teach.rkt
+++ b/htdp-lib/lang/private/teach.rkt
@@ -906,7 +906,7 @@
                               (cons prop:custom-write
                                     ;; Need a transparent-like printer, but hide auto field.
                                     ;; This simplest way to do that is to create an instance
-                                    ;; of a transparet structure with the same name and field values.
+                                    ;; of a transparent structure with the same name and field values.
                                     (let-values ([(struct:plain make-plain plain? plain-ref plain-set)
                                                   (make-struct-type 'name_ #f #,field# 0 #f null #f)])
                                       (lambda (r port mode)
@@ -2495,7 +2495,7 @@
                              (syntax id)
                              "expected a variable after set!, but found a ~a" (syntax-e #'id))]))
                        ;; If we're in a module, we'd like to check here whether
-                       ;;  the identier is bound, but we need to delay that check
+                       ;;  the identifier is bound, but we need to delay that check
                        ;;  in case the id is defined later in the module. So only
                        ;;  do this in continuing mode:
                        (when continuing?


### PR DESCRIPTION
1. `complex?` example correction.
2. a function and its application renamed in teach.rkt
3. rest are changes in comments/documentation.