### PR TITLE
Bind the internal planetcute id to a gensym.

### DIFF
--- a/htdp-lib/2htdp/planetcute.rkt
+++ b/htdp-lib/2htdp/planetcute.rkt
@@ -19,12 +19,13 @@
        (if (eq? 'expression (syntax-local-context))
            ;; In an expression context:
            (let* ([key (syntax-local-lift-context)]
+                  [id (gensym img)]
                   ;; Already lifted in this lifting context?
                   [lifted-id
                    (or (hash-ref saved-id-table key #f)
                        ;; No: lift the require for the image:
-                       (syntax-local-lift-require `(lib ,(format "~a.rkt" img) "2htdp" "planetcute")
-                                                  (datum->syntax stx img)))])
+                       (syntax-local-lift-require `(rename (lib ,(format "~a.rkt" img) "2htdp" "planetcute") ,id ,img)
+                                                  (datum->syntax stx id)))])
              (when key (hash-set! saved-id-table key lifted-id))
              ;; Expand to a use of the lifted expression:
              (with-syntax ([saved-id (syntax-local-introduce lifted-id)])

--- a/htdp-test/2htdp/tests/planetcute-runs.rkt
+++ b/htdp-test/2htdp/tests/planetcute-runs.rkt
@@ -1,0 +1,3 @@
+#lang racket
+(require 2htdp/planetcute)
+character-cat-girl


### PR DESCRIPTION
This avoids an ambigous binding error created by the new macro system. Fixes
racket/racket#1099.