### PR TITLE
Ensure `posn` also works as pattern in BSL+

### DIFF
--- a/htdp-lib/lang/htdp-beginner-abbr.rkt
+++ b/htdp-lib/lang/htdp-beginner-abbr.rkt
@@ -60,3 +60,7 @@
  procedures
  (begin)
  (all-from beginner: (submod lang/private/beginner-funs with-wrapper) procedures))
+
+;; special case, as suggested by Ryan
+(require (only-in lang/posn beginner-posn*))
+(provide (rename-out (beginner-posn* posn)))


### PR DESCRIPTION
Commit 78ecfc594c10ff70ff8f970dca97e4eac3f3f55f didn't alter BSL+ (Beginning Student with List Abbreviations). I tested this change locally on Racket 6.2.1, and the affected code is identical, but please retest before merging.

Failing example in BSL+:
```
(require 2htdp/abstraction)
(define (f x)
    (match x
      [7 8]
      ["hey" "joe"]
      [(list 1 y 3) y]
      [(cons a (list 5 6)) (add1 a)]
      [(posn 5 5) 42]
      [(posn y y) y]
      [(posn y z) (+ y z)]
      [(cons (posn 1 z) y) z]))
```

This leads to: `match: syntax error in pattern in: (posn 5 5)`.