### PR TITLE
add check-big-bang

### DIFF
--- a/htdp-doc/teachpack/2htdp/scribblings/universe.scrbl
+++ b/htdp-doc/teachpack/2htdp/scribblings/universe.scrbl
@@ -924,15 +924,18 @@ The best way to test that your program works properly is by thoroughly
 @defform[
   #:literals (make-tick make-key make-pad make-release make-mouse make-receive)
   (check-big-bang expr
-    [event expected-world]
+    clause
     ...)
-  #:grammar ([event (make-tick)
+  #:grammar ([clause [event expected-world]
+                     [event expected-world expected-msg]]
+             [event (make-tick)
                     (make-key key-event)
                     (make-pad pad-event)
                     (make-release key-event)
                     (make-mouse x y mouse-event)
                     (make-receive message)])
   #:contracts ([expected-world @#,|WorldState|]
+               [expected-msg @#,|S-expression|]
                [key-event @#,|KeyEvent|]
                [pad-event @#,|PadEvent|]
                [mouse-event @#,|MouseEvent|]

--- a/htdp-lib/2htdp/private/world.rkt
+++ b/htdp-lib/2htdp/private/world.rkt
@@ -15,7 +15,7 @@
          string-constants
          mrlib/gif)
 
-(provide world% aworld%)
+(provide world% aworld% big-bang-launches-window?)
 
 ;                                     
 ;                                     
@@ -34,6 +34,9 @@
 ;                                     
 
 (define MIN-WIDT-FOR-GAME-PAD 300)
+
+(define big-bang-launches-window?
+  (make-parameter #true))
 
 ;; -----------------------------------------------------------------------------
 ;; packages for broadcasting information to the universe 
@@ -166,7 +169,8 @@
                      "a game pad requires a scene whose width is greater or equal to ~a, given ~e"
                      MIN-WIDT-FOR-GAME-PAD fst-scene))
             (set! game-pad-image (scale (/ width (image-width game-pad)) game-pad)))
-          (create-frame)
+          (when (big-bang-launches-window?)
+            (create-frame))
           (show fst-scene)))
       
       (define/private (add-game-pad scene)
@@ -207,7 +211,8 @@
       ;; allows embedding of the world-canvas in other GUIs
       (define/public (create-frame)
         (create-frame/universe))
-      
+
+      ;; the-frame will remain #f if big-bang doesn't open a window
       ;; effect: create, show and set the-frame
       (define the-frame #f)
       (define/pubment (create-frame/universe)
@@ -419,18 +424,20 @@
 
       ;; wrap up actions 
       (define/private (wrap-up name)
-	(last-draw)
-	(callback-stop! 'name)
-	(enable-images-button)
+        (last-draw)
+        (callback-stop! 'name)
+        (enable-images-button)
         ;; in principle, a big-bang that specifies both
         ;;   [record? #true]
         ;; and
         ;;   [close-on-stop #true]
         ;; is self-contradictory; I will wait until someone complaints -- MF, 22 Nov 2015
-	(when close-on-stop
+        (when close-on-stop
           (unless (boolean? close-on-stop)
             (sleep close-on-stop))
-	  (send the-frame show #f)))
+          ;; only close the frame if there was a frame to begin with
+          (when the-frame
+            (send the-frame show #f))))
 
       (define/public (callback-stop! msg)
         (stop! (send world get)))

--- a/htdp-lib/2htdp/private/world.rkt
+++ b/htdp-lib/2htdp/private/world.rkt
@@ -35,6 +35,8 @@
 
 (define MIN-WIDT-FOR-GAME-PAD 300)
 
+;; big-bang-launches-window? : (Parameterof Boolean)
+;; Controlls whether or not big-bang launches a window and sends packages
 (define big-bang-launches-window?
   (make-parameter #true))
 
@@ -122,7 +124,11 @@
                                (if (= n 1) 
                                    (printf FMTtry register TRIES)
                                    (begin (sleep PAUSE) (try (- n 1)))))))
-              (define-values (in out) (tcp-connect register port))
+              (define-values (in out)
+                (if (big-bang-launches-window?)
+                    (tcp-connect register port)
+                    (values (open-input-string "" 'mock-server)
+                            (open-output-string 'sent-messages))))
               (tcp-register in out name)
               (printf "... successful registered and ready to receive\n")
               (set! *out* out)

--- a/htdp-test/2htdp/tests/check-big-bang.rkt
+++ b/htdp-test/2htdp/tests/check-big-bang.rkt
@@ -48,6 +48,7 @@
   [(make-tick)        (make-posn 1 1)]
   [(make-key "right") (make-posn 6 1)]
   [(make-tick)        (make-posn 7 2)]
+  [(make-key " ")     (make-posn 7 2) (list "AT" (list 7 2))]
   [(make-key "left")  (make-posn 2 2)]
   [(make-key "down")  (make-posn 2 7)]
   [(make-tick)        (make-posn 3 8)]
@@ -77,6 +78,7 @@
         [(key=? k "right") (make-posn (+ (posn-x p) 5) (posn-y p))]
         [(key=? k "up")    (make-posn (posn-x p) (- (posn-y p) 5))]
         [(key=? k "down")  (make-posn (posn-x p) (+ (posn-y p) 5))]
+        [(key=? k " ")     (make-package p (list "AT" (list (posn-x p) (posn-y p))))]
         [else p]))
 
 ;; posn-handle-mouse : Posn Integer Integer Mouse-Event -> Posn

--- a/htdp-test/2htdp/tests/check-big-bang.rkt
+++ b/htdp-test/2htdp/tests/check-big-bang.rkt
@@ -1,0 +1,93 @@
+#lang htdp/bsl
+(require 2htdp/image)
+(require 2htdp/universe)
+
+;; nat-main : Natural -> Natural
+(define (nat-main t)
+  (big-bang t
+    [on-tick add1]
+    [on-key nat-handle-key]
+    [to-draw draw-circle]))
+
+(check-big-bang (nat-main 0)
+  [(make-tick) 1]
+  [(make-tick) 2]
+  [(make-tick) 3]
+  [(make-key "left") 2]
+  [(make-tick) 3]
+  [(make-key "right") 4]
+  [(make-tick) 5]
+  [(make-key "left") 4]
+  [(make-key "left") 3]
+  [(make-key "left") 2]
+  [(make-key "left") 1]
+  [(make-key "left") 0]
+  [(make-key "left") 0]
+  [(make-tick) 1])
+
+;; draw-circle : PosNum -> Image
+(define (draw-circle r)
+  (circle r "solid" "red"))
+
+;; handle-key : Natural KeyEvent -> Natural
+(define (nat-handle-key t k)
+  (cond [(key=? k "left") (max 0 (sub1 t))]
+        [(key=? k "right") (add1 t)]
+        [else t]))
+
+;; posn-main : Posn -> Posn
+;; Lanches a big-bang window
+(define (posn-main p)
+  (big-bang p
+    [on-tick move-posn]
+    [on-key posn-handle-key]
+    [on-mouse posn-handle-mouse]
+    [to-draw display-ball]))
+
+(check-big-bang (posn-main (make-posn 0 0))
+  [(make-tick)        (make-posn 1 1)]
+  [(make-key "right") (make-posn 6 1)]
+  [(make-tick)        (make-posn 7 2)]
+  [(make-key "left")  (make-posn 2 2)]
+  [(make-key "down")  (make-posn 2 7)]
+  [(make-tick)        (make-posn 3 8)]
+  [(make-mouse 100 50 "button-down") (make-posn 100 50)]
+  [(make-tick)        (make-posn 101 51)])
+
+(check-big-bang* (posn-main (make-posn 0 0))
+  (list
+   (make-event-expect (make-tick)        (make-posn 1 1))
+   (make-event-expect (make-key "right") (make-posn 6 1))
+   (make-event-expect (make-tick)        (make-posn 7 2))
+   (make-event-expect (make-key "left")  (make-posn 2 2))
+   (make-event-expect (make-key "down")  (make-posn 2 7))
+   (make-event-expect (make-tick)        (make-posn 3 8))
+   (make-event-expect (make-mouse 100 50 "button-down") (make-posn 100 50))
+   (make-event-expect (make-tick)        (make-posn 101 51))))
+
+
+;; move-posn : Posn -> Posn
+(define (move-posn p)
+  (make-posn (+ (posn-x p) 1)
+             (+ (posn-y p) 1)))
+
+;; posn-handle-key : Posn Key -> Posn
+(define (posn-handle-key p k)
+  (cond [(key=? k "left")  (make-posn (- (posn-x p) 5) (posn-y p))]
+        [(key=? k "right") (make-posn (+ (posn-x p) 5) (posn-y p))]
+        [(key=? k "up")    (make-posn (posn-x p) (- (posn-y p) 5))]
+        [(key=? k "down")  (make-posn (posn-x p) (+ (posn-y p) 5))]
+        [else p]))
+
+;; posn-handle-mouse : Posn Integer Integer Mouse-Event -> Posn
+(define (posn-handle-mouse p x y m)
+  (cond [(mouse=? m "button-down") (make-posn x y)]
+        [else p]))
+
+;; display-ball : Posn -> Image
+(define BG (empty-scene 500 500))
+(define (display-ball p)
+  (place-image (circle 20 "solid" "blue")
+               (posn-x p) (posn-y p)
+               BG))
+


### PR DESCRIPTION
This adds `check-big-bang` and `check-big-bang*` to `2htdp/universe`. A usage of `check-big-bang` looks like:

``` racket
(check-big-bang (main (make-posn 0 0))
  [(make-tick)        (make-posn 1 1)]
  [(make-key "right") (make-posn 6 1)]
  [(make-tick)        (make-posn 7 2)]
  [(make-key "left")  (make-posn 2 2)]
  [(make-key "down")  (make-posn 2 7)]
  [(make-tick)        (make-posn 3 8)]
  [(make-mouse 100 50 "button-down") (make-posn 100 50)]
  [(make-tick)        (make-posn 101 51)])
```

The `check-big-bang*` version of this would look like:

``` racket
(check-big-bang* (main (make-posn 0 0))
  (list
   (make-event-expect (make-tick)        (make-posn 1 1))
   (make-event-expect (make-key "right") (make-posn 6 1))
   (make-event-expect (make-tick)        (make-posn 7 2))
   (make-event-expect (make-key "left")  (make-posn 2 2))
   (make-event-expect (make-key "down")  (make-posn 2 7))
   (make-event-expect (make-tick)        (make-posn 3 8))
   (make-event-expect (make-mouse 100 50 "button-down") (make-posn 100 50))
   (make-event-expect (make-tick)        (make-posn 101 51))))
```

The documentation still isn't finished, and it also doesn't handle sent messages properly yet.
