### PR TITLE
add section-index for student lang. abbreviations

### DIFF
--- a/htdp-doc/scribblings/htdp-langs/advanced.scrbl
+++ b/htdp-doc/scribblings/htdp-langs/advanced.scrbl
@@ -4,6 +4,8 @@
 
 @title[#:tag "advanced"]{Advanced Student}
 
+@section-index["ASL"]
+
 @declare-exporting[lang/htdp-advanced]
 
 @racketgrammar*+qq[

--- a/htdp-doc/scribblings/htdp-langs/beginner-abbr.scrbl
+++ b/htdp-doc/scribblings/htdp-langs/beginner-abbr.scrbl
@@ -4,6 +4,8 @@
 
 @title[#:tag "beginner-abbr"]{Beginning Student with List Abbreviations}
 
+@section-index["BSL+"]
+
 @declare-exporting[lang/htdp-beginner-abbr]
 
 @racketgrammar*+qq[

--- a/htdp-doc/scribblings/htdp-langs/beginner.scrbl
+++ b/htdp-doc/scribblings/htdp-langs/beginner.scrbl
@@ -5,6 +5,8 @@
 
 @title[#:tag "beginner"]{Beginning Student}
 
+@section-index["BSL"]
+
 @declare-exporting[lang/htdp-beginner #:use-sources (lang/htdp-beginner lang/private/teachprims)]
 
 @racketgrammar*+library[

--- a/htdp-doc/scribblings/htdp-langs/intermediate-lambda.scrbl
+++ b/htdp-doc/scribblings/htdp-langs/intermediate-lambda.scrbl
@@ -4,6 +4,8 @@
 
 @title[#:tag "intermediate-lam"]{Intermediate Student with Lambda}
 
+@section-index["ISL+"]
+
 @declare-exporting[lang/htdp-intermediate-lambda]
 
 @racketgrammar*+qq[

--- a/htdp-doc/scribblings/htdp-langs/intermediate.scrbl
+++ b/htdp-doc/scribblings/htdp-langs/intermediate.scrbl
@@ -5,6 +5,8 @@
 
 @title[#:tag "intermediate"]{Intermediate Student}
 
+@section-index["ISL"]
+
 @declare-exporting[lang/htdp-intermediate]
 
 @racketgrammar*+qq[


### PR DESCRIPTION
Searching for 'BSL' 'BSL+' 'ISL' 'ISL+' and 'ASL' now
points to the language documentation.

(I'm pretty sure this works, but I haven't successfully tested it. Do I need to delete my whole `racket/doc` folder before running `raco setup`?)