### PR TITLE
Update htdp-lib deps.

### DIFF
--- a/htdp-lib/info.rkt
+++ b/htdp-lib/info.rkt
@@ -3,7 +3,7 @@
 (define collection 'multi)
 
 (define deps
-  '(["base" #:version "6.2.900.10"]
+  '(["base" #:version "6.8.0.2"]
     "compatibility-lib"
     "draw-lib"
     ("drracket-plugin-lib" #:version "1.1")


### PR DESCRIPTION
This is because the previous commit: d9c3cafc3035ce26d5266da5fe36d40d6626fa1c
relies on `racket/math`'s definition of `natural?`, which was added yesterday.