### PR TITLE
update requires for TR PR

### DIFF
--- a/htdp-lib/typed/test-engine/type-env-ext.rkt
+++ b/htdp-lib/typed/test-engine/type-env-ext.rkt
@@ -6,8 +6,8 @@
           racket/base syntax/parse
           (utils tc-utils)
           (env init-envs)
-          (except-in (rep filter-rep object-rep type-rep) make-arr)
-          (rename-in (types abbrev numeric-tower union) [make-arr* make-arr])))
+          (rep filter-rep object-rep type-rep)
+          (types abbrev numeric-tower union)))
 
 (define-for-syntax ce-env
   (make-env


### PR DESCRIPTION
update this file to be compatible with a TR PR which does some refactoring w.r.t. arrow types (https://github.com/racket/typed-racket/pull/566)

P.S. does this file still (`type-env-ext.rkt`) need to exist as is? (i.e. do some of the newer require/provide forms do the same thing without requiring internal TR definitions?)