### PR TITLE
Fix error message for 3rd argument to make-bundle

### DIFF
--- a/htdp-lib/2htdp/private/universe.rkt
+++ b/htdp-lib/2htdp/private/universe.rkt
@@ -371,11 +371,10 @@
     (unless (pred? c)
       (error 
        tag
-       "expects a list of mails as ~a argument, given a list that contains: ~e"
+       "expects a list of ~as as ~a argument, given a list that contains: ~e"
+       msg
        ith
        c)))
-  #;
-  (check-arg tag  msg (format "(elements of) ~a" ith) c)
   )
 
 ;; Symbol Any ->* Universe [Listof Mail] [Listof IWorld]


### PR DESCRIPTION
The error message `make-bundle: expects a list of mails as third argument, given a list that contains:` is wrong.
This commit fixes it by changing `mails` to `iworlds`.