### PR TITLE
Do not re-raise exceptions in `run-and-check`

### DIFF
--- a/htdp-lib/test-engine/racket-tests.rkt
+++ b/htdp-lib/test-engine/racket-tests.rkt
@@ -425,7 +425,7 @@
     (cond [(check-fail? result)
            (define c (send test-engine get-info))
            (send c check-failed result (check-fail-src result) exn)
-           (if exn (raise exn) #f)]
+           #f]
           [else #t])))
 
 ;;Wishes


### PR DESCRIPTION
I'm not fully confident that this is the correct way to avoid errors aborting test-suite execution, but it seems to work; exceptions are still reported but do not prevent later tests from running. Fixes #19.