### PR TITLE
Stop stepper window jumping to top.

### DIFF
--- a/htdp-lib/stepper/private/view-controller.rkt
+++ b/htdp-lib/stepper/private/view-controller.rkt
@@ -351,7 +351,11 @@
       (send canvas set-editor e)
       (send e reset-width canvas)
       ;; why set the position within the step? I'm confused by this.--JBC
-      (send e set-position (send e last-position))
+      ;;
+      ;; gfb responding: this didn't. The editor has three large snips on one line,
+      ;; so setting the position to the end set it to the top end of that one line.
+      #;(send e set-position (send e last-position))
+
       (send e end-edit-sequence))
     (update-status-bar))
   


### PR DESCRIPTION
Very simple safe improvement: remove the incorrect setting of position which caused it to always jump to the top. Leaving the position alone will usually jump to the bottom, which is usually better if the choice is between top and bottom. Partly addresses https://github.com/racket/drracket/issues/162 .