### PR TITLE
Stop stepper window jumping to top.

### DIFF
--- a/htdp-lib/stepper/private/view-controller.rkt
+++ b/htdp-lib/stepper/private/view-controller.rkt
@@ -350,8 +350,6 @@
       (send e begin-edit-sequence)
       (send canvas set-editor e)
       (send e reset-width canvas)
-      ;; why set the position within the step? I'm confused by this.--JBC
-      (send e set-position (send e last-position))
       (send e end-edit-sequence))
     (update-status-bar))
   


### PR DESCRIPTION
This change will usually have it jump to the bottom instead, which is an improvement if the choice is simply between top and bottom.

The editor contains three items (pre-step, arrow, post-step) on one line, so setting the position to the end of the editor was putting the cursor at the end of that very long line, at the top of the view.

Partly addresses racket/drracket#162 .