### PR TITLE
Provide a type for  `check-random`.

### DIFF
--- a/htdp-lib/typed/test-engine/type-env-ext.rkt
+++ b/htdp-lib/typed/test-engine/type-env-ext.rkt
@@ -77,6 +77,15 @@
            (when _
              (insert-test _ (lambda () (check-member-of-values-expected _ _ _ _ _))))))
        #'check-member-of-values-expected])
-    ((-> Univ) Univ (-lst Univ) Univ Univ . -> . -Void)]))
+    ((-> Univ) Univ (-lst Univ) Univ Univ . -> . -Void)]
+   ;; check-random-values
+   [(syntax-parse (local-expand #'(ce:check-random 1 1) 'module #f)
+      #:literals (let* when define-values)
+      [(define-values _
+         (let* ((_ _) (_ _))
+           (when _
+             (insert-test _ (lambda () (check-random-values _ _ _ _))))))
+       #'check-random-values])
+    ((-> Univ) (-> Univ) (-lst Univ) Univ . -> . -Void)]))
 
 (begin-for-syntax (initialize-type-env ce-env))


### PR DESCRIPTION
This PR adds a type for `check-random` from `test-engine`. It requires some small refactoring to how `check-random` works -- setting the seed and random generator is done in the testing function directly instead of in the macro that generates a call to that function.

I would appreciate feedback from people who know this code,
particularly @mfelleisen and @jbclements.