### PR TITLE
Fix check-range documentation to allow inexact numbers.

### DIFF
--- a/htdp-doc/scribblings/htdp-langs/prim-ops.rkt
+++ b/htdp-doc/scribblings/htdp-langs/prim-ops.rkt
@@ -685,7 +685,7 @@ functions that compute inexact numbers:
 @;%
 
 It is an error for @racket[expression], @racket[low-expression], or
-@racket[high-expression] to produce a function value or an inexact number;
+@racket[high-expression] to produce a function value;
 see note on @racket[check-expect] for details.  }
 
   @; ----------------------------------------------------------------------


### PR DESCRIPTION
The documentation currently says that it's an error for any of the three
expressions given to `check-range` to produce an inexact number. But
inexact numbers are exactly what `check-range` is intended for, and it's
not actually an error to use it on them:

    (check-range pi (sub1 pi) (add1 pi))
    (check-range pi pi pi)