### PR TITLE
Redo struct signatures

### DIFF
--- a/htdp-lib/lang/htdp-advanced.rkt
+++ b/htdp-lib/lang/htdp-advanced.rkt
@@ -66,9 +66,9 @@
          #%top-interaction
          empty
          
-         signature : -> mixed one-of predicate combined
-         Number Real Rational Integer Natural Boolean True False String Symbol Char Empty-list Any
-         cons-of
+         signature : -> mixed enum predicate combined
+         Number Real Rational Integer Natural Boolean True False String Symbol Char Any
+         ConsOf ListOf EmptyList
          Property
          check-property for-all ==> expect expect-within expect-member-of expect-range)
 

--- a/htdp-lib/lang/private/advanced-funs.rkt
+++ b/htdp-lib/lang/private/advanced-funs.rkt
@@ -1,5 +1,11 @@
 #lang at-exp scheme/base
   (require "teachprims.rkt"
+           (only-in "teach.rkt"
+                    Integer Number Rational Real Natural
+                    Boolean True False
+                    String Char Symbol
+                    EmptyList ConsOf
+                    Any)
            mzlib/etc
            mzlib/list
            mzlib/pretty
@@ -405,4 +411,48 @@
       heqv
       (hash-eqv? heqv)
       ]
+    })
+
+   ("Signatures"
+    @defthing[Number signature?]{
+    Signature for arbitrary numbers.
+    }
+    @defthing[Natural signature?]{
+    Signature for natural numbers.
+    }
+    @defthing[Integer signature?]{
+    Signature for integers.
+    }
+    @defthing[Rational signature?]{
+    Signature for rational numbers.
+    }
+    @defthing[Real signature?]{
+    Signature for real numbers.
+    }
+    @defthing[Boolean signature?]{
+    Signature for booleans.
+    }
+    @defthing[True signature?]{
+    Signature for just true.
+    }
+    @defthing[False signature?]{
+    Signature for just false.
+    }
+    @defthing[String signature?]{
+    Signature for strings.
+    }
+    @defthing[Char signature?]{
+    Signature for chararacters.
+    }
+    @defthing[Symbol signature?]{
+    Signature for symbols.
+    }
+    @defthing[EmptyList signature?]{
+    Signature for the empty list.
+    }
+    @defproc[(ConsOf [first-sig signature?] [rest-sig signature?]) signature?]{
+    Signature for a cons pair.
+    }
+    @defthing[Any signature?]{
+    Signature for any value.
     }))

--- a/htdp-lib/lang/private/signature-syntax.rkt
+++ b/htdp-lib/lang/private/signature-syntax.rkt
@@ -1,9 +1,9 @@
-#lang scheme/base
+#lang racket/base
 
 (provide :
 	 signature signature/arbitrary
 	 define/signature define-values/signature
-	 -> mixed one-of predicate combined property list-of vector-of)
+	 -> mixed enum predicate combined property ListOf VectorOf)
 
 (require deinprogramm/signature/signature
 	 deinprogramm/signature/signature-english
@@ -22,7 +22,7 @@
 
 (define-for-syntax (parse-signature name stx)
   (syntax-case* stx
-		(mixed one-of predicate list-of vector-of -> combined property reference at signature)
+		(mixed enum predicate ListOf VectorOf -> combined property reference at signature)
 		module-or-top-identifier=?
     ((mixed ?signature ...)
      (with-syntax ((?stx (phase-lift stx))
@@ -33,7 +33,7 @@
        #'(make-mixed-signature '?name
 			      (list ?signature-expr ...)
 			      ?stx)))
-    ((one-of ?exp ...)
+    ((enum ?exp ...)
      (with-syntax ((((?temp ?exp) ...) 
 		    (map list
 			 (generate-temporaries #'(?exp ...)) (syntax->list #'(?exp ...))))
@@ -56,23 +56,23 @@
      (with-syntax ((?stx (phase-lift stx))
 		   (?name name))
        #'(make-predicate-signature '?name (delay ?exp) ?stx)))
-    ((list-of ?signature)
+    ((ListOf ?signature)
      (with-syntax ((?stx (phase-lift stx))
 		   (?name name)
 		   (?signature-expr (parse-signature #f #'?signature)))
        #'(make-list-signature '?name ?signature-expr ?stx)))
-    ((list-of ?signature1 ?rest ...)
+    ((ListOf ?signature1 ?rest ...)
      (raise-syntax-error #f
-			 "list-of signature accepts only a single operand"
+			 "ListOf signature accepts only a single operand"
 			 (syntax ?signature1)))
-    ((vector-of ?signature)
+    ((VectorOf ?signature)
      (with-syntax ((?stx (phase-lift stx))
 		   (?name name)
 		   (?signature-expr (parse-signature #f #'?signature)))
        #'(make-vector-signature '?name ?signature-expr ?stx)))
-    ((vector-of ?signature1 ?rest ...)
+    ((VectorOf ?signature1 ?rest ...)
      (raise-syntax-error #f
-			 "vector-of signature accepts only a single operand"
+			 "VectorOf signature accepts only a single operand"
 			 (syntax ?signature1)))
     ((?arg-signature ... -> ?return-signature)
      (with-syntax ((?stx (phase-lift stx))
@@ -255,9 +255,9 @@
 
 (define-syntax -> within-signature-syntax-transformer)
 (define-syntax mixed within-signature-syntax-transformer)
-(define-syntax one-of within-signature-syntax-transformer)
+(define-syntax enum within-signature-syntax-transformer)
 (define-syntax predicate within-signature-syntax-transformer)
 (define-syntax combined within-signature-syntax-transformer)
 (define-syntax property within-signature-syntax-transformer)
-(define-syntax list-of within-signature-syntax-transformer)
-(define-syntax vector-of within-signature-syntax-transformer)
+(define-syntax ListOf within-signature-syntax-transformer)
+(define-syntax VectorOf within-signature-syntax-transformer)

--- a/htdp-test/tests/htdp-lang/signatures.rkt
+++ b/htdp-test/tests/htdp-lang/signatures.rkt
@@ -1,0 +1,82 @@
+; Tests for signatures, specifically struct signatures
+#lang racket/base
+
+(require rackunit
+         (only-in lang/private/teach
+                  beginner-define-struct advanced-define-struct
+                  signature
+                  Integer Boolean)
+         deinprogramm/signature/signature)
+
+(define-syntax say-no
+  (syntax-rules ()
+    ((_ ?body ...)
+     (let/ec exit
+       (call-with-signature-violation-proc
+	(lambda (obj signature message blame)
+	  (exit 'no))
+	(lambda ()
+	  ?body ...))))))
+
+(define-syntax failed-signature
+  (syntax-rules ()
+    ((_ ?body ...)
+     (let/ec exit
+       (call-with-signature-violation-proc
+	(lambda (obj signature message blame)
+	  (exit signature))
+	(lambda ()
+	  ?body ...))))))
+
+(define-syntax failed-signature-name
+  (syntax-rules ()
+    ((_ ?body ...)
+     (let/ec exit
+       (call-with-signature-violation-proc
+	(lambda (obj signature message blame)
+	  (exit (signature-name signature)))
+	(lambda ()
+	  ?body ...))))))
+
+; Need to test both beginner and advanced
+(advanced-define-struct dillo (alive? weight))
+(advanced-define-struct parrot (sentence weight))
+
+(define d1 (make-dillo #f 10))
+
+(check-eq? (say-no (apply-signature Dillo d1)) d1)
+(check-eq? (say-no (apply-signature Dillo #f)) 'no)
+(check-eq? (say-no (apply-signature Dillo (make-parrot "hello" 10))) 'no)
+(check-eq? (say-no (apply-signature (DilloOf Boolean Integer) d1)) d1)
+(check-eq? (say-no (apply-signature (DilloOf Boolean Integer) #f)) 'no)
+(check-eq? (say-no (apply-signature (DilloOf Boolean Integer) (make-parrot "hello" 10))) 'no)
+
+(check-eq? (failed-signature-name (apply-signature (DilloOf Boolean Integer) (make-dillo 10 10)))
+           'Boolean)
+(check-eq? (failed-signature-name (apply-signature (DilloOf Boolean Integer) (make-dillo #f #f)))
+           'Integer)
+
+(beginner-define-struct empty-list ())
+
+(define nil (make-empty-list))
+
+(beginner-define-struct pare (kar kdr))
+
+(define (kons a d) (make-pare a d))
+
+(define (ListOf a)
+  (signature
+   (mixed EmptyList
+          (PareOf a (ListOf a)))))
+
+(define list123 (kons 1 (kons 2 (kons 3 nil))))
+
+(check-equal? (say-no (apply-signature (ListOf Integer)
+                                       list123))
+              list123)
+(check-equal? (say-no (apply-signature (ListOf Integer) #f))
+              'no)
+
+(check-eq? (say-no (apply-signature (ListOf Integer)
+                                    (kons 1 (kons #f (kons 3 nil)))))
+           'no)


### PR DESCRIPTION
This is from a discussion Matthias Felleisen and I had at ICFP 2019:

The previous version of the signature support had as the name of the
signature the name of the struct, which made for confusing error
messages.

Now, camelcase the struct name: dillo -> Dillo, foo-bar -> FooBar.

This is in line with HtDP's conventions, I think.  Also, primitive
signatures start with an upper-case letter.

The signature constructors append an "Of": DilloOf, FooBarOf etc.