### PR TITLE
fix broken link to htdp 2e

### DIFF
--- a/htdp-doc/scribblings/htdp-langs/common.rkt
+++ b/htdp-doc/scribblings/htdp-langs/common.rkt
@@ -16,7 +16,7 @@
 @; -----------------------------------------------------------------------------
 (define dots (bold "..."))
 
-(define htdp "http://www.ccs.neu.edu/home/matthias/HtDP2e/")
+(define htdp "https://htdp.org/2018-01-06/Book/")
 (define i1-2 (string-append htdp "i1-2.html"))
 (define i2-3 (string-append htdp "i2-3.html"))
 

--- a/htdp-doc/scribblings/htdp-langs/common.rkt
+++ b/htdp-doc/scribblings/htdp-langs/common.rkt
@@ -16,7 +16,7 @@
 @; -----------------------------------------------------------------------------
 (define dots (bold "..."))
 
-(define htdp "https://htdp.org/2018-01-06/Book/")
+(define htdp "https://htdp.org/2020-5-6/Book/")
 (define i1-2 (string-append htdp "i1-2.html"))
 (define i2-3 (string-append htdp "i2-3.html"))
 


### PR DESCRIPTION
http://www.ccs.neu.edu/home/matthias/HtDP2e/i1-2.html is now 
https://htdp.org/2018-01-06/Book/i1-2.html

reported by Alice on slack https://racket.slack.com/archives/C06V96CKX/p1592042294076100