### PR TITLE
annotate add-check-expect-tests!

### DIFF
--- a/htdp-lib/typed/test-engine/type-env-ext.rkt
+++ b/htdp-lib/typed/test-engine/type-env-ext.rkt
@@ -19,6 +19,12 @@
    [(syntax-parse (local-expand #'(ce:check-expect 1 1) 'module #f)
       #:literals (define-values)
       [(define-values _
+          (add-check-expect-test! _))
+       #'add-check-expect-test!])
+      ((-> Univ) . -> . -Void)]
+   [(syntax-parse (local-expand #'(ce:check-expect 1 1) 'module #f)
+      #:literals (define-values)
+      [(define-values _
          (add-check-expect-test! (lambda () (do-check-expect _ _ _))))
        #'do-check-expect])
     ((-> Univ) Univ Univ . -> . -Boolean)]


### PR DESCRIPTION
I saw error messages related to this problem when running the CI for typed racket
```
"typed-racket-test/succeed/check-expect.rkt:1:6: Type Checker: missing type for identifier;\n consider using `require/typed' to import it\n  identifier: add-check-expect-test!\n  from module: racket-tests.rkt\n  in: #%module-begin"
2020-10-31T14:08:11.0370727Z exception:
2020-10-31T14:08:11.0372672Z   #(struct:exn:fail:syntax "typed-racket-test/succeed/check-expect.rkt:1:6: Type Checker: missing type for identifier;\n consider using `require/typed' to import it\n  identifier: add-check-expect-test!\n  from module: racket-tests.rkt\n  in: #%module-begin" #<continuation-mark-set> (#<syntax #%module-begin>))
```

on my machine, now all typed racket tests pass with this fix, but I am not sure if this is the right way to type `add-check-expect-tests!`