### PR TITLE
Split out test engine syntax

### DIFF
--- a/htdp-lib/htdp/bsl/runtime.rkt
+++ b/htdp-lib/htdp/bsl/runtime.rkt
@@ -7,7 +7,7 @@
          racket/snip
          racket/class
          (only-in test-engine/test-markup get-rewritten-error-message-parameter)
-         (only-in test-engine/racket-tests report-signature-violation!)
+         (only-in test-engine/syntax report-signature-violation!)
          (only-in deinprogramm/signature/signature signature-violation-proc)
          "print-width.rkt")
 

--- a/htdp-lib/lang/htdp-langs.rkt
+++ b/htdp-lib/lang/htdp-langs.rkt
@@ -33,7 +33,7 @@
          "htdp-langs-save-file-prefix.rkt"
          "htdp-langs-interface.rkt"
 
-         (only-in test-engine/racket-tests
+         (only-in test-engine/syntax
                   report-signature-violation! test-execute test)
 	 (except-in test-engine/test-engine signature-violation)
          test-engine/test-markup

--- a/htdp-lib/lang/private/teach-module-begin.rkt
+++ b/htdp-lib/lang/private/teach-module-begin.rkt
@@ -10,7 +10,7 @@
 
 (require deinprogramm/signature/signature
          lang/private/signature-syntax
-         test-engine/racket-tests)
+         (only-in test-engine/syntax test))
 
 (require (for-syntax scheme/base)
          (for-syntax racket/list)

--- a/htdp-lib/lang/private/teach.rkt
+++ b/htdp-lib/lang/private/teach.rkt
@@ -49,7 +49,8 @@
          (rename lang/private/signature-syntax signature:property property)
          (all-except deinprogramm/quickcheck/quickcheck property)
          (rename deinprogramm/quickcheck/quickcheck quickcheck:property property)
-         (only test-engine/racket-tests exn:fail:wish check-expect-maker)
+         (only test-engine/racket-tests)
+         (only test-engine/syntax check-expect-maker)
          (only test-engine/test-engine
                add-wish! add-wish-call! add-failed-check!
                property-error property-fail

--- a/htdp-lib/stepper/private/model.rkt
+++ b/htdp-lib/stepper/private/model.rkt
@@ -51,7 +51,7 @@
          "model-settings.rkt"
          "macro-unwind.rkt"
          "lifting.rkt"
-         (only-in test-engine/racket-tests test-silence)
+         (only-in test-engine/syntax test-silence)
          
          ;; for breakpoint display
          ;; (commented out to allow nightly testing)

--- a/htdp-lib/test-engine/README.md
+++ b/htdp-lib/test-engine/README.md
@@ -9,6 +9,8 @@ teaching languages.
 - `info.rkt`: package information
 - `test-engine.rkt`: register tests, run them, collect & inspect results
 - `racket-tests.rkt`: surface syntax for the teaching languages
+- `syntax.rkt`: utilities for defining surface syntax in a way that
+  works with the stepper
 - `markup-gui.rkt`: graphical rendering for markup in a `text%` object
 - `test-markup.rkt`: convert test results into markup
 - `srcloc.rkt`: extract source location from the stack trace in an exception

--- a/htdp-lib/test-engine/syntax.rkt
+++ b/htdp-lib/test-engine/syntax.rkt
@@ -1,0 +1,123 @@
+; Utiltities for creating languages like syntax in a stepper-compatible way
+#lang racket/base
+
+(provide (for-syntax check-expect-maker) ; helper syntax for creating the above
+         execute-test ; helper for using check-expect-maker
+         test ; run tests and display results
+         test-execute ; boolean parameter, says if the tests run
+         test-silence ; boolean parameter, says if the test results are printed
+         report-signature-violation!)
+
+;; check-expect-maker : syntax? syntax? (listof syntax?) symbol? -> syntax?
+;; the common part of all three test forms
+
+; NB: typed/test-engine/type-env-ext and stepper/private/macro-unwind.rkt
+;     KNOW THE STRUCTURE OF THE GENERATED SYNTAX.
+; TREAD CAREFULLY.
+
+(require (for-syntax racket/base)
+         (for-syntax stepper/private/syntax-property)
+         test-engine/test-engine
+         (only-in deinprogramm/signature/signature
+                  exn:fail:contract:signature?
+                  exn:fail:contract:signature-obj exn:fail:contract:signature-signature
+                  exn:fail:contract:signature-blame)
+         test-engine/srcloc
+         test-engine/test-markup
+         (only-in syntax/macro-testing convert-compile-time-error))
+
+(define-for-syntax (check-expect-maker stx checker-proc-stx test-expr embedded-stxes hint-tag)
+  (define bogus-name
+    (stepper-syntax-property #`#,(gensym 'test) 'stepper-hide-completed #t))
+  (define src-info
+    (with-stepper-syntax-properties (['stepper-skip-completely #t])
+      #`(srcloc #,@(list #`(quote #,(syntax-source stx))
+                         (syntax-line stx)
+                         (syntax-column stx)
+                         (syntax-position stx)
+                         (syntax-span stx)))))
+  (define test-expr-checked-for-syntax-error #`(convert-compile-time-error #,test-expr))
+  (if (eq? 'module (syntax-local-context))
+      #`(define #,bogus-name
+          #,(stepper-syntax-property
+             #`(add-check-expect-test!
+                (lambda ()
+                  #,(with-stepper-syntax-properties
+                      (['stepper-hint hint-tag]
+                       ['stepper-hide-reduction #t]
+                       ['stepper-use-val-as-final #t])
+                      (quasisyntax/loc stx
+                        (#,checker-proc-stx
+                         (lambda () #,test-expr-checked-for-syntax-error)
+                         #,@embedded-stxes
+                         #,src-info)))))
+             'stepper-skipto
+             (append skipto/cdr
+                     skipto/second ;; outer lambda
+                     '(syntax-e cdr cdr syntax-e car) ;; inner lambda
+                     )))
+      #`(add-check-expect-test!
+         (lambda ()
+           #,(with-stepper-syntax-properties
+               (['stepper-hint hint-tag]
+                ['stepper-hide-reduction #t]
+                ['stepper-use-val-as-final #t])
+               (quasisyntax/loc stx
+                 (#,checker-proc-stx
+                  (lambda () #,test-expr-checked-for-syntax-error)
+                  #,@embedded-stxes
+                  #,src-info)))))))
+
+; this wrapper is necessary because add-test! has a contract which confuses the stepper
+(define (add-check-expect-test! thunk)
+  (add-test! thunk))
+
+(define (execute-test src thunk exn:fail->reason)
+  (let-values (((test-result exn)
+                 (with-handlers ([exn:fail:contract:signature?
+                                  (lambda (e)
+                                    (values
+                                     (violated-signature src
+                                                         (exn:fail:contract:signature-obj e)
+                                                         (exn:fail:contract:signature-signature e)
+                                                         (exn:fail:contract:signature-blame e))
+                                     e))]
+                                 [exn:fail?
+                                  (lambda (e)
+                                    (values (exn:fail->reason e) e))])
+                   (values (thunk) #f))))
+    (if (fail-reason? test-result)
+        (begin
+          (add-failed-check! (failed-check test-result (and (exn? exn) (exn-srcloc exn))))
+          #f)
+        #t)))
+
+
+(define (report-signature-violation! obj signature message blame)
+  (let* ([srcloc (continuation-marks-srcloc (current-continuation-marks))]
+         [message
+          (or message
+              (signature-got obj))])
+    (add-signature-violation! (signature-violation obj signature message srcloc blame))))
+
+; typed/test-engine/typen-env-ext knows what this expands into
+(define-syntax (test stx) 
+  (syntax-case stx ()
+    [(_)
+     (syntax-property
+      #'(test*)
+      'test-call #t)]))
+
+(define test-execute (make-parameter #t))
+(define test-silence (make-parameter #f))
+
+(define (test*)
+  (when (test-execute)
+    (run-tests!))
+  (unless (test-silence)
+    (display-test-results! (test-object->markup (current-test-object) (not (test-execute)))))
+  ;; make sure we return void - anything else might get printed in the REPL
+  (void))
+
+
+

--- a/htdp-test/htdp/tests/test-docs-complete.rkt
+++ b/htdp-test/htdp/tests/test-docs-complete.rkt
@@ -18,10 +18,7 @@
             #:skip (lambda (h)
                      (memq h
                            ;; probably obsolete
-                           '(exn:fail:wish
-                             ;; internal, likely to be refactored somewhere else
-                             report-signature-violation!
-                             execute-test))))
+                           '(exn:fail:wish exn:fail:wish-args exn:fail:wish-name exn:fail:wish? struct:exn:fail:wish))))
 (check-docs (quote htdp/show-queen))
 (check-docs (quote htdp/servlet2) #:skip legacy-module)
 (check-docs (quote htdp/servlet) #:skip legacy-module)


### PR DESCRIPTION
This way, other languages can use the same utilities without
inheriting the same concrete syntax.

Also, fixes namespace pollution that got noticed by the test-docs-complete check.