### PR TITLE
Disable test engine if the plugin is not loaded

### DIFF
--- a/htdp-lib/lang/htdp-langs.rkt
+++ b/htdp-lib/lang/htdp-langs.rkt
@@ -143,7 +143,8 @@
                 [scheme-signature-module-name
                  ((current-module-name-resolver) 
                   '(lib "deinprogramm/signature/signature-english.rkt") #f #f #t)]
-                [tests-on? (preferences:get 'test-engine:enable?)])
+                [tests-on? (with-handlers ([exn:unknown-preference? (λ (e) #f)])
+                             (preferences:get 'test-engine:enable?))])
             (run-in-user-thread
              (lambda ()
                (when (getenv "PLTDRHTDPNOCOMPILED") (use-compiled-file-paths '()))
@@ -168,9 +169,10 @@
                   (report-signature-violation! obj signature message blame)))
                (display-test-results-parameter
                 (lambda (markup)
-                  (test-display-results! (drscheme:rep:current-rep)
-                                         drs-eventspace
-                                         markup)))
+                  (when (test-execute)
+                    (test-display-results! (drscheme:rep:current-rep)
+                                           drs-eventspace
+                                           markup))))
                (get-rewritten-error-message-parameter get-rewriten-error-message)
                (test-execute tests-on?)
                (signature-checking-enabled?


### PR DESCRIPTION
If the test engine plugin is not loaded, the preference
`test-engine:enable?` won't have a default value. Therefore
disable the test engine if the preference test-engine:enable?
is not found.