### PR TITLE
Unfify printing

### DIFF
--- a/htdp-lib/htdp/bsl/runtime.rkt
+++ b/htdp-lib/htdp/bsl/runtime.rkt
@@ -1,32 +1,69 @@
 #lang racket/base
+(provide configure configure/settings
+         options->sl-runtime-settings
+         (struct-out sl-runtime-settings)
+         sl-render-value/format)
+
 (require mzlib/pconvert
          racket/pretty
          lang/private/set-result
          lang/private/rewrite-error-message
-         mrlib/image-core
+         (prefix-in image-core: mrlib/image-core)
+         mrlib/cache-image-snip
+         (only-in racket/draw bitmap%)
          racket/snip
          racket/class
-         (only-in test-engine/test-markup get-rewritten-error-message-parameter)
+         (only-in test-engine/test-markup get-rewritten-error-message-parameter render-value-parameter)
          (only-in test-engine/syntax report-signature-violation!)
          (only-in deinprogramm/signature/signature
                   signature? signature-name
                   signature-violation-proc)
+         (only-in simple-tree-text-markup/construct number)
+         simple-tree-text-markup/text
          "print-width.rkt")
 
-(provide configure)
+(struct sl-runtime-settings
+  (printing-style ; write, trad-write, print, quasiquote
+   fraction-style ; mixed-fraction, mixed-fraction-e, repeating-decimal, repeating-decimal-e
+   show-sharing?
+   insert-newlines?
+   tracing? ; unclear if this should be here
+   true/false/empty-as-ids?
+   abbreviate-cons-as-list?
+   use-function-output-syntax?))
+
+(define insert-newlines (make-parameter #t))
+
+(define (options->sl-runtime-settings options)
+  (sl-runtime-settings 'print
+                       'repeating-decimal
+                       (and (memq 'show-sharing options) #t)
+                       #t ; insert-newlines?
+                       #f ; tracing?
+                       #f ; true/false/empty-as-ids?
+                       (and (memq 'abbreviate-cons-as-list options) #t)
+                       (and (memq 'use-function-output-syntax options) #t)))
 
 (define (configure options)
+  (configure/settings (options->sl-runtime-settings options)))
+
+(define (configure/settings settings)
   ;; Set print-convert options:
-  (booleans-as-true/false #f)
+  (booleans-as-true/false (sl-runtime-settings-true/false/empty-as-ids? settings))
   (print-boolean-long-form #t)
-  (constructor-style-printing #t)
-  (add-make-prefix-to-constructor #f)
-  (abbreviate-cons-as-list (memq 'abbreviate-cons-as-list options))
+  [constructor-style-printing
+   (case (sl-runtime-settings-printing-style settings)
+     [(quasiquote) #f]
+     [else #t])]
+  (print-as-expression #f)
+  (add-make-prefix-to-constructor #t)
+  (abbreviate-cons-as-list (sl-runtime-settings-abbreviate-cons-as-list? settings))
+  (insert-newlines (sl-runtime-settings-insert-newlines? settings))
   (current-print-convert-hook
    (let ([ph (current-print-convert-hook)])
      (lambda (val basic sub)
        (cond
-         [(equal? val '()) ''()]
+         [(and (not (sl-runtime-settings-true/false/empty-as-ids? settings)) (equal? val '())) ''()]
          [(equal? val set!-result) '(void)]
          [(signature? val)
           (or (signature-name val)
@@ -35,56 +72,120 @@
          [else (ph val basic sub)]))))
   (use-named/undefined-handler
    (lambda (x)
-     (and (memq 'use-function-output-syntax options)
+     (and (sl-runtime-settings-use-function-output-syntax? settings)
           (procedure? x)
           (object-name x))))
   (named/undefined-handler
    (lambda (x)
      (string->symbol
       (format "function:~a" (object-name x)))))
-  ;; Set pretty-print options:
-  (pretty-print-show-inexactness #t)
-  (pretty-print-exact-as-decimal #t)
+
+  ; sharing done by print-convert
+  (show-sharing (sl-runtime-settings-show-sharing? settings))
+  ; sharing done by write
+  (print-graph (and (sl-runtime-settings-show-sharing? settings)
+                    ;; print-convert takes care of this also, so only do it when that doesn't happen
+                    (case (sl-runtime-settings-printing-style settings)
+                      ([trad-write write] #t)
+                      (else #f))))
+
   (define img-str "#<image>")
   (define (is-image? val)
-    (or (is-a? val image%)         ;; 2htdp/image
-        (is-a? val image-snip%)))  ;; literal image constant
-  (show-sharing (memq 'show-sharing options))
+    (or (is-a? val image-core:image%) ; 2htdp/image
+        (is-a? val cache-image-snip%) ; htdp/image
+        (is-a? val image-snip%) ; literal image constant
+        (is-a? val bitmap%))) ; works in other places, so include it here too
 
-  ;; Set print handlers to use print-convert and pretty-write:
-  (define (set-handlers thunk)
-    (parameterize ([pretty-print-print-hook
-                    (let ([oh (pretty-print-print-hook)])
-                      (λ (val display? port)
-                        (if (and (not (port-writes-special? port))
-                                 (is-image? val))
-                            (begin (display img-str port)
-                                   (string-length img-str))
-                            (oh val display? port))))]
-                   [pretty-print-size-hook
-                    (let ([oh (pretty-print-size-hook)])
-                      (λ (val display? port)
-                        (if (and (not (port-writes-special? port))
-                                 (is-image? val))
-                            (string-length img-str)
-                            (oh val display? port))))])
-      (thunk)))
+  ;; exact fractions - slight hack as we know for what numbers DrRacket generates special snips
+  (define (use-number-markup? x)
+    (and (number? x)
+         (exact? x)
+         (real? x)
+         (not (integer? x))))
+
+  (define fraction-view
+    (case (sl-runtime-settings-fraction-style settings)
+      [(mixed-fraction mixed-fraction-e) 'mixed]
+      [(repeating-decimal repeating-decimal-e) 'decimal]))
+
+  (pretty-print-show-inexactness #t)
+  (pretty-print-exact-as-decimal (eq? fraction-view 'decimal))
+
+  (pretty-print-print-hook
+   (let ([oh (pretty-print-print-hook)])
+     (λ (val display? port)
+       (cond
+        [(and (not (port-writes-special? port))
+              (is-image? val))
+         (display img-str port)]
+        [(and (use-number-markup? val)
+              (port-writes-special? port))
+         (write-special (number val #:exact-prefix 'never #:inexact-prefix 'always #:fraction-view fraction-view) port)]
+        [(number? val)
+         (display (number-markup->string val #:exact-prefix 'never #:inexact-prefix 'always #:fraction-view fraction-view) port)]
+        [else
+         (oh val display? port)]))))
+
+  (pretty-print-size-hook
+   (let ([oh (pretty-print-size-hook)])
+     (λ (val display? port)
+       (cond
+         [(and (not (port-writes-special? port))
+               (is-image? val))
+          (string-length img-str)]
+        [(and (use-number-markup? val)
+              (port-writes-special? port))
+         1]
+        [(number? val)
+         (string-length (number-markup->string val #:exact-prefix 'never #:inexact-prefix 'always #:fraction-view fraction-view))]
+        [else
+         (oh val display? port)]))))
+
+  ; test-engine
   (get-rewritten-error-message-parameter get-rewriten-error-message)
+  ; test-engine
+  (render-value-parameter
+   (lambda (value port)
+     (parameterize ([print-value-columns 40])
+       (print value port))))
+
   (error-display-handler
    (let ([o-d-h (error-display-handler)])
      (λ (msg exn)
        (define x (get-rewriten-error-message exn))
        (o-d-h x exn))))
-  (let ([orig (global-port-print-handler)])
-    (global-port-print-handler
-     (lambda (val port [depth 0])
-       (parameterize ([global-port-print-handler orig])
-         (let ([val (print-convert val)])
-           (set-handlers
-            (λ ()
-              (parameterize ([pretty-print-columns (htdp-print-columns)])
-                (pretty-write val port)))))))))
+
+  (global-port-print-handler
+   (lambda (val port [depth 0])
+     (define printing-style (sl-runtime-settings-printing-style settings))
+     (define cols
+       (if (exact-integer? (print-value-columns)) ;; print-value-columns takes precedence
+           (print-value-columns)
+           (htdp-print-columns)))
+
+     (parameterize ([print-value-columns (if (eqv? cols 'infinity)
+                                             +inf.0
+                                             cols)]
+                    [pretty-print-columns
+                     (if (sl-runtime-settings-insert-newlines? settings)
+                         cols
+                         'infinity)])
+       (let [(val (case printing-style
+                    [(write trad-write) val]
+                    [else (print-convert val)]))]
+         (case printing-style
+           [(print) (pretty-print val port depth)]
+           [(write trad-write constructor) (pretty-write val port)]
+           [(quasiquote) (pretty-write val port)])))))
 
   (signature-violation-proc
    (lambda (obj signature message blame)
      (report-signature-violation! obj signature message blame))))
+
+(define (sl-render-value/format value port width)
+  (parameterize ([print-value-columns (if (eq? width 'infinity)
+                                          +inf.0
+                                          width)])
+    (print value port)
+    (unless (insert-newlines)
+      (newline port))))

--- a/htdp-lib/lang/private/sl-stepper-button.rkt
+++ b/htdp-lib/lang/private/sl-stepper-button.rkt
@@ -13,29 +13,15 @@
          lang/private/set-result
          lang/stepper-language-interface
          (only-in deinprogramm/signature/signature signature? signature-name)
+         htdp/bsl/runtime
          stepper/drracket-button)
 
 (define (sl-stepper-drracket-button options)
-  (let ([settings (options->settings options)])
+  (let ([settings (options->sl-runtime-settings options)])
     (stepper-drracket-button (new sl-stepper-language% [settings settings]) settings)))
 
 (define-logger stepper)
 
-(define-struct simple-settings (show-sharing
-                                insert-newlines
-                                true/false/empty-as-ids?
-                                abbreviate-cons-as-list
-                                use-function-output-syntax?))
-
-(define (present? key options)
-  (and (memq key options) #t))
-
-(define (options->settings options)
-  (make-simple-settings (present? 'show-sharing options)
-                        #t #f ; vestige from old levels
-                        (present? 'abbreviate-cons-as-list options)
-                        (present? 'use-function-output-syntax options)))
-   
 (define sl-stepper-language%
   (class* object% (stepper-language<%>)
 
@@ -51,7 +37,7 @@
     ;; the language definition to match the way that the language
     ;; wants these values printed.
     (public stepper:show-lambdas-as-lambdas?)
-    (define (stepper:show-lambdas-as-lambdas?) (simple-settings-use-function-output-syntax? settings))
+    (define (stepper:show-lambdas-as-lambdas?) (sl-runtime-settings-use-function-output-syntax? settings))
 
     (public stepper:show-inexactness?)
     (define (stepper:show-inexactness?) #t)
@@ -68,173 +54,14 @@
         (log-stepper-debug "render-to-sexp got a boolean: ~v\n" val))
       (or (and (procedure? val)
                (object-name val))
-          (parameterize ([pretty-print-show-inexactness (stepper:show-inexactness?)]
-                         [current-print-convert-hook stepper-print-convert-hook])
-            (call-with-values
-             (lambda ()
-               ;; I'm not sure that these print settings actually need to be set...
-               ;; or... that they need to be set *here*. They might need to be set
-               ;; when the pretty-print to the actual width occurs. That is, when
-               ;; they get converted to strings...
-               ;; try removing this wrapper when things are working. (2015-10-22)
-               (call-with-print-settings
-                language-level
-                settings
-                (lambda ()
-                  (simple-module-based-language-convert-value
-                   val
-                   settings))))
-             (lambda args
-               (match args
-                 [(list value should-be-written?)
-                  (cond [should-be-written?
-                         ;; warning, don't know if this happens in the stepper:
-                         (log-stepper-debug "print-convert returned writable: ~v\n" value)
-                         value]
-                        [else
-                         ;; apparently some values should be written and some should be printed.
-                         ;; Since we formulate a single value to send to the output, this is hard
-                         ;; for us.
-                         ;; A cheap hack is to print the value and then read it again.
-                         ;; Unfortunately, this fails on images. To layer a second hack on
-                         ;; the first one, we intercept this failure and just return the
-                         ;; value.
-                         (with-handlers ([exn:fail:read?
-                                          (λ (exn)
-                                            (log-stepper-debug
-                                             "read fail, print convert returning: ~s\n"
-                                             value)
-                                            value)])
-                           (define result-value
-                             (let ([os-port (open-output-string)])
-                               (print value os-port)
-                               (when (boolean? val)
-                                 (log-stepper-debug "string printed by print: ~v\n" (get-output-string os-port)))
-                               ;; this 'read' is somewhat scary. I'd like to
-                               ;; get rid of this:
-                               (read (open-input-string (get-output-string os-port)))))
-                           (log-stepper-debug "print-convert returned string that read mapped to: ~s\n" result-value)
-                           result-value)])]
-                 [(list value)
-                  (log-stepper-debug "render-to-sexp: value returned from convert-value: ~v\n" value)
-                  value]))))))
+          (print-convert val)))
 
     (public render-value)
     (define (render-value val settings port)
-      (set-printing-parameters
-       settings
-       (lambda ()
-         (teaching-language-render-value/format val settings port 'infinity))))
-
-    (public set-printing-parameters)
-    (define (set-printing-parameters settings thunk)
-      (define img-str "#<image>")
-      (define (is-image? val)
-        (or (is-a? val ic:image%)         ;; 2htdp/image
-            (is-a? val cache-image-snip%) ;; htdp/image
-            (is-a? val image-snip%)       ;; literal image constant
-            (is-a? val bitmap%)))         ;; works in other places, so include it here too
-      (define tfe-ids? (simple-settings-true/false/empty-as-ids? settings))
-      (parameterize ([pc:booleans-as-true/false tfe-ids?]
-                     [pc:add-make-prefix-to-constructor #t]
-                     [print-boolean-long-form #t]
-                     [pc:abbreviate-cons-as-list (simple-settings-abbreviate-cons-as-list settings)]
-                     [pc:current-print-convert-hook
-                      (let ([ph (pc:current-print-convert-hook)])
-                        (lambda (val basic sub)
-                          (cond
-                            [(and (not tfe-ids?) (equal? val '())) ''()]
-                            [(equal? val set!-result) '(void)]
-                            [(signature? val)
-                             (or (signature-name val)
-                                 '<signature>)]
-                            [(bytes? val)
-                             (if (< (bytes-length val) 100)
-                                 val
-                                 (bytes-append (subbytes val 0 99) #"... truncated"))]
-                            [else (ph val basic sub)])))]
-                     [pretty-print-show-inexactness #t]
-                     [pretty-print-exact-as-decimal #t]
-                     [pretty-print-print-hook
-                      (let ([oh (pretty-print-print-hook)])
-                        (λ (val display? port)
-                          (if (and (not (port-writes-special? port))
-                                   (is-image? val))
-                              (begin (display img-str port)
-                                     (string-length img-str))
-                              (oh val display? port))))]
-                     [pretty-print-size-hook
-                      (let ([oh (pretty-print-size-hook)])
-                        (λ (val display? port)
-                          (if (and (not (port-writes-special? port))
-                                   (is-image? val))
-                              (string-length img-str)
-                              (oh val display? port))))]
-                     [pc:use-named/undefined-handler
-                      (lambda (x)
-                        (and (simple-settings-use-function-output-syntax? settings)
-                             (procedure? x)
-                             (object-name x)))]
-                     [pc:named/undefined-handler
-                      (lambda (x)
-                        (string->symbol
-                         (format "function:~a" (object-name x))))])
-        (thunk)))
+      (parameterize ([print-value-columns +inf.0])
+        (print val port)))
     
     (super-instantiate ())))
 
-(define (teaching-language-render-value/format value settings port width)
-  (let*-values ([(converted-value write?)
-                 (call-with-values
-                  (lambda ()
-                    (simple-module-based-language-convert-value value settings))
-                  (case-lambda
-                    [(converted-value) (values converted-value #t)]
-                    [(converted-value write?) (values converted-value write?)]))])
-    (let ([pretty-out (if write? pretty-write pretty-print)])
-      (cond
-        [(simple-settings-insert-newlines settings)
-         (if (number? width)
-             (parameterize ([pretty-print-columns width])
-               (pretty-out converted-value port))
-             (pretty-out converted-value port))]
-        [else
-         (parameterize ([pretty-print-columns 'infinity])
-           (pretty-out converted-value port))
-         (newline port)]))))
-
-(define (stepper-print-convert-hook exp basic-convert sub-convert)
-  (cond
-    [(is-a? exp snip%) (send exp copy)]
-    [else (basic-convert exp)]))
-
-;; set-print-settings ; settings ( -> TST) -> TST
-(define (call-with-print-settings language simple-settings thunk)
-  ;; this should succeed for the teaching languges, and fail otherwise.
-  ;; if there's a way to directly check this, I should do it. As an approximation,
-  ;; the else clause will be guarded by a check for PLTSTEPPERUNSAFE
-  (if (method-in-interface? 'set-printing-parameters (object-interface language))
-      (send language set-printing-parameters simple-settings thunk)
-      ;; should only wind up here for non-teaching-languages:
-      (cond [(getenv "PLTSTEPPERUNSAFE") (thunk)]
-            [else
-             (thunk)
-             ;; this error occurs in htdp/bsl etc.
-             #;(error
-              'stepper-tool
-              "language object does not contain set-printing-parameters method")])))
-
-(define (simple-module-based-language-convert-value value settings)
-  (parameterize ([constructor-style-printing #t]
-                 [show-sharing (simple-settings-show-sharing settings)]
-                 [current-print-convert-hook (leave-snips-alone-hook (current-print-convert-hook))])
-    (print-convert value)))
-
-(define ((leave-snips-alone-hook sh) expr basic-convert sub-convert)
-  (if (or (is-a? expr snip%)
-          (is-a? expr bitmap%))
-      ; we're missing to-snip here
-      expr
-      (sh expr basic-convert sub-convert)))
 
 

--- a/htdp-lib/test-engine/markup-gui.rkt
+++ b/htdp-lib/test-engine/markup-gui.rkt
@@ -98,7 +98,13 @@
             (else
              (insert-markup (image-markup-alt-markup markup) text src-editor))))
          (else
-          (insert-markup (image-markup-alt-markup markup) text src-editor)))))))
+          (insert-markup (image-markup-alt-markup markup) text src-editor)))))
+    [(number-markup? markup)
+     (send text insert
+           (number-snip:number->string/snip (number-markup-number markup)
+                                            #:exact-prefix (number-markup-exact-prefix markup)
+                                            #:inexact-prefix (number-markup-inexact-prefix markup)
+                                            #:fraction-view (number-markup-fraction-view markup)))]))
      
 (define (for-each/between proc between list)
   (let loop ((list list))


### PR DESCRIPTION
... across the menu-based *SL, #lang htdp/*sl, and the stepper.

To that end, bind global-port-print-handler to a procedure that can do
all the work, and use it from all the other places.