### PR TITLE
Require simple-tree-text-markup-lib or above

### DIFF
--- a/htdp-lib/info.rkt
+++ b/htdp-lib/info.rkt
@@ -18,7 +18,7 @@
     "sandbox-lib"
     "scheme-lib"
     "scribble-lib"
-    "simple-tree-text-markup-lib"
+    ["simple-tree-text-markup-lib" #:version "1.1"]
     "slideshow-lib"
     "snip-lib"
     "srfi-lite-lib"


### PR DESCRIPTION
The dependency is introduced here: racket/simple-tree-text-markup#2.
