### PR TITLE
Fix #171

### DIFF
--- a/htdp-doc/teachpack/2htdp/scribblings/abstraction.scrbl
+++ b/htdp-doc/teachpack/2htdp/scribblings/abstraction.scrbl
@@ -281,8 +281,9 @@ applicable ideas of program design.
               (match case-expr (pattern body-expr) ...)
               ([pattern 
                  name 
-	         literal-constant
+	             literal-constant
                  (cons pattern pattern)
+                 (list pattern ...)
                  (name pattern ...)
                  (? name)])]{
  dispatches like a @racket[cond], matching the result of @racket[case-expr]
@@ -304,6 +305,8 @@ applicable ideas of program design.
 @item{@racket[(cons pattern_1 pattern_2)], it matches when the value is an
  instance of @racket[cons], and its first/rest fields match @racket[pattern_1] 
  and @racket[pattern_2], respectively;}
+@item{@racket[(list pattern ...)], it matches when the value is a @racket[list],
+ and each element matches its corresponding @racket[pattern];}
 @item{@racket[(name pattern ...)], it matches when the value is an instance of
  the @racket[name] structure type, and its field values match @racket[pattern]
  ...;} 
@@ -318,19 +321,31 @@ The following @racket[match] expression distinguishes @racket[cons]es with
 @racket['()] in the second position from all others: 
 @interaction[#:eval (make-base-eval '(require 2htdp/abstraction))
 (define (last-item l)
-   (match l 
-     [(cons lst '()) lst]
-     [(cons fst rst) (last-item rst)]))
+  (match l
+    [(cons lst '()) lst]
+    [(cons fst rst) (last-item rst)]))
 
 (last-item '(a b c))
 ]
 
-With ?, a @racket[match] can use a predicate to distinguish arbitrary values: 
+The following @racket[match] expression extracts the @racket[title] of an HTML page
+in the nested @racket[list] representation:
+@interaction[#:eval (make-base-eval '(require 2htdp/abstraction))
+(define (get-title page)
+  (match page
+    [(list 'html (list 'head (list 'title title)) body) title]
+    [anything "Untitled"]))
+
+(get-title '(html (head (title "hello")) (body (p "world"))))
+(get-title '(html (head) (body (p "world"))))
+]
+
+With @racket[?], a @racket[match] can use a predicate to distinguish arbitrary values:
 @interaction[#:eval (make-base-eval '(require 2htdp/abstraction))
 (define (is-it-odd-or-even l)
-   (match l 
-     [(? even?) 'even]
-     [(? odd?)  'odd]))
+  (match l
+    [(? even?) 'even]
+    [(? odd?)  'odd]))
 
 (is-it-odd-or-even '1)
 (is-it-odd-or-even '2)

--- a/htdp-lib/2htdp/abstraction.rkt
+++ b/htdp-lib/2htdp/abstraction.rkt
@@ -32,7 +32,8 @@
  (rename-out (match0 match)))
 
 ;; ---------------------------------------------------------------------------------------------------
-(require (for-syntax syntax/parse)
+(require (for-syntax syntax/parse
+                     racket/struct-info)
          syntax/parse 
          plai 
          htdp/error
@@ -114,7 +115,33 @@
     [(_ type:id case:expr [variant:id (field:id ...) body:expr] ...)
      #'(type-case type case [variant (field ...) body] ...)]))
 
+(begin-for-syntax
+  (define-syntax-class pattern-cls
+    #:description "pattern"
+    #:attributes (expr)
+    (pattern name:id
+             #:with expr #'name)
+
+    ;; literal-constants
+    (pattern {~or* :string :number :boolean :char :regexp :bytes :byte-regexp}
+             #:with expr this-syntax)
+    (pattern ({~datum quote} x)
+             #:with expr #'(quote x))
+
+    (pattern ({~datum cons} left:pattern-cls right:pattern-cls)
+             #:with expr #'(cons left.expr right.expr))
+    (pattern ({~datum ?} e:id)
+             #:with expr #'(? e))
+    (pattern (st e:pattern-cls ...)
+             #:declare st (static struct-info? "structure type")
+             #:with expr #'(struct st (e.expr ...)))
+
+    ;; for stuff like posn that pretends to be a struct
+    (pattern (st e:pattern-cls ...)
+             #:declare st (static match-expander? "structure type")
+             #:with expr #'(st e.expr ...))))
+
 (define-syntax (match0 stx)
   (syntax-parse stx
-    [(_ case:expr (pattern body:expr) ...)
-     #'(match case (pattern body) ...)]))
+    [(_ case:expr (pat:pattern-cls body:expr) ...)
+     #'(match case (pat.expr body) ...)]))

--- a/htdp-lib/2htdp/abstraction.rkt
+++ b/htdp-lib/2htdp/abstraction.rkt
@@ -119,13 +119,8 @@
   (define-syntax-class pattern-cls
     #:description "pattern"
     #:attributes (match-pattern)
-    (pattern {~datum ...}
-             #:do [(raise-syntax-error 'match
-                                       "... is not supported"
-                                       this-syntax)]
-             #:with match-pattern #'dummy)
     (pattern name:id
-             #:with match-pattern #'name)
+             #:with match-pattern #'(var name))
 
     ;; literal-constants
     (pattern {~or* :string :number :boolean :char :regexp :bytes :byte-regexp}

--- a/htdp-lib/2htdp/abstraction.rkt
+++ b/htdp-lib/2htdp/abstraction.rkt
@@ -119,6 +119,11 @@
   (define-syntax-class pattern-cls
     #:description "pattern"
     #:attributes (match-pattern)
+    (pattern {~datum ...}
+             #:do [(raise-syntax-error 'match
+                                       "... is not supported"
+                                       this-syntax)]
+             #:with match-pattern #'dummy)
     (pattern name:id
              #:with match-pattern #'name)
 
@@ -131,8 +136,12 @@
     (pattern ({~datum cons} left:pattern-cls right:pattern-cls)
              #:with match-pattern #'(cons left.match-pattern
                                           right.match-pattern))
+    (pattern ({~datum list} p:pattern-cls ...)
+             #:with match-pattern #'(list p.match-pattern ...))
+
     (pattern ({~datum ?} e:id)
              #:with match-pattern #'(? e))
+
     (pattern (st e:pattern-cls ...)
              #:declare st (static struct-info? "structure definition")
              #:with match-pattern #'(struct st (e.match-pattern ...)))

--- a/htdp-lib/2htdp/abstraction.rkt
+++ b/htdp-lib/2htdp/abstraction.rkt
@@ -118,30 +118,31 @@
 (begin-for-syntax
   (define-syntax-class pattern-cls
     #:description "pattern"
-    #:attributes (expr)
+    #:attributes (match-pattern)
     (pattern name:id
-             #:with expr #'name)
+             #:with match-pattern #'name)
 
     ;; literal-constants
     (pattern {~or* :string :number :boolean :char :regexp :bytes :byte-regexp}
-             #:with expr this-syntax)
+             #:with match-pattern this-syntax)
     (pattern ({~datum quote} x)
-             #:with expr #'(quote x))
+             #:with match-pattern #'(quote x))
 
     (pattern ({~datum cons} left:pattern-cls right:pattern-cls)
-             #:with expr #'(cons left.expr right.expr))
+             #:with match-pattern #'(cons left.match-pattern
+                                          right.match-pattern))
     (pattern ({~datum ?} e:id)
-             #:with expr #'(? e))
+             #:with match-pattern #'(? e))
     (pattern (st e:pattern-cls ...)
-             #:declare st (static struct-info? "structure type")
-             #:with expr #'(struct st (e.expr ...)))
+             #:declare st (static struct-info? "structure definition")
+             #:with match-pattern #'(struct st (e.match-pattern ...)))
 
     ;; for stuff like posn that pretends to be a struct
     (pattern (st e:pattern-cls ...)
-             #:declare st (static match-expander? "structure type")
-             #:with expr #'(st e.expr ...))))
+             #:declare st (static match-expander? "structure definition")
+             #:with match-pattern #'(st e.match-pattern ...))))
 
 (define-syntax (match0 stx)
   (syntax-parse stx
     [(_ case:expr (pat:pattern-cls body:expr) ...)
-     #'(match case (pat.expr body) ...)]))
+     #'(match case (pat.match-pattern body) ...)]))

--- a/htdp-test/2htdp/tests/abstraction-errors.rkt
+++ b/htdp-test/2htdp/tests/abstraction-errors.rkt
@@ -27,3 +27,4 @@
 
 
 (exn/msg "expected structure definition" (match 1 [(var x) x]))
+(exn/msg "... is not supported" (match '(1 2 3) [(list xs ...) 1]))

--- a/htdp-test/2htdp/tests/abstraction-errors.rkt
+++ b/htdp-test/2htdp/tests/abstraction-errors.rkt
@@ -27,4 +27,3 @@
 
 
 (exn/msg "expected structure definition" (match 1 [(var x) x]))
-(exn/msg "... is not supported" (match '(1 2 3) [(list xs ...) 1]))

--- a/htdp-test/2htdp/tests/abstraction-errors.rkt
+++ b/htdp-test/2htdp/tests/abstraction-errors.rkt
@@ -24,3 +24,6 @@
 (exn/msg "expected identifier" (for/list ([y 2][(+ 1 1) 10]) 10))
 (exn/msg "expected identifier" (for/list ([x 1] ([(x y) a z])) 10))
 (exn/msg "expected identifier" (for/list ([x 1][10 x]) 10))
+
+
+(exn/msg "expected structure type" (match 1 [(var x) x]))

--- a/htdp-test/2htdp/tests/abstraction-errors.rkt
+++ b/htdp-test/2htdp/tests/abstraction-errors.rkt
@@ -26,4 +26,4 @@
 (exn/msg "expected identifier" (for/list ([x 1][10 x]) 10))
 
 
-(exn/msg "expected structure type" (match 1 [(var x) x]))
+(exn/msg "expected structure definition" (match 1 [(var x) x]))

--- a/htdp-test/2htdp/tests/abstraction-use.rkt
+++ b/htdp-test/2htdp/tests/abstraction-use.rkt
@@ -122,5 +122,16 @@
 
 (define (undress a-doll)
   (match a-doll
-    [(struct doll (inside)) (undress inside)]
+    [(doll inside) (undress inside)]
     [(? symbol?) a-doll]))
+
+;; -----------------------------------------------------------------------------
+
+;; GitHub Issue #171
+
+(define-struct var (x))
+(define (ee expr)
+  (match expr
+    [(var x) 1]
+    [catch-all 2]))
+(check-expect (ee 10) 2)

--- a/htdp-test/2htdp/tests/abstraction-use.rkt
+++ b/htdp-test/2htdp/tests/abstraction-use.rkt
@@ -148,3 +148,7 @@
 (check-expect (test-list '(1 3)) 3)
 (check-expect (test-list '(4 2)) 4)
 (check-expect (test-list '((5))) 5)
+
+(check-expect (match 1
+                [_ _])
+              1)

--- a/htdp-test/2htdp/tests/abstraction-use.rkt
+++ b/htdp-test/2htdp/tests/abstraction-use.rkt
@@ -137,3 +137,14 @@
 
 (check-expect (ee 10) 2)
 (check-expect (ee (make-var 11)) 1)
+
+(define (test-list xs)
+  (match xs
+    [(list 1 x) x]
+    [(list y 2) y]
+    [(list (list z)) z]))
+
+(check-expect (test-list '(1 2)) 2)
+(check-expect (test-list '(1 3)) 3)
+(check-expect (test-list '(4 2)) 4)
+(check-expect (test-list '((5))) 5)

--- a/htdp-test/2htdp/tests/abstraction-use.rkt
+++ b/htdp-test/2htdp/tests/abstraction-use.rkt
@@ -134,4 +134,6 @@
   (match expr
     [(var x) 1]
     [catch-all 2]))
+
 (check-expect (ee 10) 2)
+(check-expect (ee (make-var 11)) 1)


### PR DESCRIPTION
Here's one possible fix.

I'm kinda uncomfortable with assuming that any match expander is pretending to be a struct. This is mostly to make `posn` (which uses a custom match expander) work. I can use a trick similar to https://racket.discourse.group/t/impersonate-syntax-transformer-cursed-or-not/971/13 to make this more precise, if that's really a concern.

I recognize `quote`, `?`, and `cons` by textual appearance (`~datum`), not by binding. Let me know if this should be changed.

Also, I recognize many literal constants that Racket allows, just to be safe. But let me know if I should remove any.

Also, I strictly follow the grammar, so the `list` pattern is not supported. Let me know if it should be supported, and I'll adjust both documentation and implementation.