### PR TITLE
fix typo in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-This component of Racket is distributed under the under the Apache 2.0
-and MIT licenses. The user can choose the license under which they
-will be using the software. There may be other licenses within the
+This component of Racket is distributed under the Apache 2.0 and MIT
+licenses. The user can choose the license under which they will be
+using the software. There may be other licenses within the
 distribution with which the user must also comply.
 
 See the files

--- a/htdp-doc/LICENSE
+++ b/htdp-doc/LICENSE
@@ -1,6 +1,6 @@
-This component of Racket is distributed under the under the Apache 2.0
-and MIT licenses. The user can choose the license under which they
-will be using the software. There may be other licenses within the
+This component of Racket is distributed under the Apache 2.0 and MIT
+licenses. The user can choose the license under which they will be
+using the software. There may be other licenses within the
 distribution with which the user must also comply.
 
 See the files

--- a/htdp-lib/LICENSE
+++ b/htdp-lib/LICENSE
@@ -1,6 +1,6 @@
-This component of Racket is distributed under the under the Apache 2.0
-and MIT licenses. The user can choose the license under which they
-will be using the software. There may be other licenses within the
+This component of Racket is distributed under the Apache 2.0 and MIT
+licenses. The user can choose the license under which they will be
+using the software. There may be other licenses within the
 distribution with which the user must also comply.
 
 See the files

--- a/htdp-test/LICENSE
+++ b/htdp-test/LICENSE
@@ -1,6 +1,6 @@
-This component of Racket is distributed under the under the Apache 2.0
-and MIT licenses. The user can choose the license under which they
-will be using the software. There may be other licenses within the
+This component of Racket is distributed under the Apache 2.0 and MIT
+licenses. The user can choose the license under which they will be
+using the software. There may be other licenses within the
 distribution with which the user must also comply.
 
 See the files

--- a/htdp/LICENSE
+++ b/htdp/LICENSE
@@ -1,6 +1,6 @@
-This component of Racket is distributed under the under the Apache 2.0
-and MIT licenses. The user can choose the license under which they
-will be using the software. There may be other licenses within the
+This component of Racket is distributed under the Apache 2.0 and MIT
+licenses. The user can choose the license under which they will be
+using the software. There may be other licenses within the
 distribution with which the user must also comply.
 
 See the files


### PR DESCRIPTION
Remove duplicated "under the" and reformat lines with 70 limit.