### PR TITLE
Add signatures to *SL.

### DIFF
--- a/htdp-doc/scribblings/htdp-langs/advanced.scrbl
+++ b/htdp-doc/scribblings/htdp-langs/advanced.scrbl
@@ -330,142 +330,15 @@ level as they did in the @secref["intermediate-lam"] level.
              true false
              #:with-beginner-function-call #f)
 
-@section[#:tag "advanced-signatures"]{Signatures}
-
-Signatures do not have to be comment: They can also be part of the
-code.  When a signature is attached to a function, DrRacket will check
-that program uses the function in accordance with the signature and
-display signature violations along with the test results.
-
-A signature is a regular value, and is specified as a
-@seclink["advanced-signature-forms"]{@italic{signature form}}, a
-special syntax that only works with @racket[:] signature declarations
-and inside @racket[signature] expressions.
-
-@defform[(: name signature-form)]{
-This attaches the signature specified by @racket[signature-form] to
-the definition of @racket[name].
-There must be a definition of @racket[name] somewhere in the program.
-
-@racketblock[
-(: age Integer)
-(define age 42)
-
-(: area-of-square (Number -> Number)) 
-(define (area-of-square len)
-  (sqr len))
-  ]
-
-On running the program, Racket checks whether the signatures attached
-with @racket[:] actually match the value of the variable.  If they
-don't, Racket reports @italic{signature violation} along with test failures.
-
-For example, this piece of code:
-
-@racketblock[
-(: age Integer)
-(define age "fortytwo")
-]
-
-Yields this output:
-
-@verbatim{
-1 signature violation.
-
-Signature violations:
-        got "fortytwo" at line 2, column 12, signature at line 1, column 7
-}
-
-Note that a signature violation does not stop the running program.
-}
-
-@defform[(signature signature-form)]{
-This returns the signature described by @racket[signature-form] as a value.
-}
-
-@subsection[#:tag "advanced-signature-forms"]{Signature Forms}
-
-Any expression can be a signature form, in which case the signature is
-the value returned by that expression.  There are a few special
-signature forms, however:
-
-In a signature form, any name that starts with a @racketvalfont{%} is a
-@italic{signature variable} that stands for any signature depending on how
-the signature is used.
-
-Example:
-
-@racketblock[
-(: same (%a -> %a))
-
-(define (same x) x)
-]
-
-@defform[#:id -> (input-signature-form ... -> output-signature-form)]{
-This signature form describes a function with inputs described by the
-@racket[input-signature-form]s and output described by
-@racket[output-signature-form].
-}	
-
-@defform[(enum expr ...)]{
-This signature describes an enumeration of the values returned by the @racket[expr]s.
-
-Example:
-
-@racketblock[
-(: cute? ((enum "cat" "snake") -> Boolean))
-
-(define (cute? pet)
-  (cond
-    [(string=? pet "cat") #t]
-    [(string=? pet "snake") #f]))
-]
-}
-
-@defform[(mixed signature-form ...)]{
-This signature describes mixed data, i.e. an itemization where
-each of the cases has a signature described by a @racket[signature-form].
-
-Example:
-
-@racketblock[(define SIGS (signature (mixed Aim Fired)))]
-}
-
-@defform[(ListOf signature-form)]{
-This signature describes a list where the elements are described by
-@racket[signature-form].
-}
-
-
-@subsection[#:tag "struct-signatures"]{Struct Signatures}
-
-A @racket[define-struct] form defines two additional names that can be
-used in signatures.  For a struct called @racketvalfont{struct}, these
-are @racketvalfont{Struct} and @racketvalfont{StructOf}.  Note that
-these names are capitalized.  In particular, a struct called
-@racketvalfont{Struct}, will also define @racketvalfont{Struct} and
-@racketvalfont{StructOf}.  Moreover, when forming the additional
-names, hyphens are removed, and each letter following a hyphen is
-capitalized - so a struct called @racketvalfont{foo-bar} will define
-@racketvalfont{FooBar} and @racketvalfont{FooBarOf}.
-
-@racketvalfont{Struct} is a signature that describes struct values
-from this structure type.  @racketvalfont{StructOf} is a function
-that takes as input a signature for each field.  It returns a
-signature describing values of this structure type, additionally
-describing the values of the fields of the value.
-
-@racketblock[
-(define-struct pair [fst snd])
-
-(: add-pair ((PairOf Number Number) -> Number))
-(define (add-pair p)
-  (+ (pair-fst p) (pair-snd p)))
-]
-
 @; ----------------------------------------
 
 @section[#:tag "advanced-pre-defined"]{Pre-Defined Functions}
+
+@; --------------------------------------------------
+
+@section[#:tag "advanced-signatures"]{Signatures}
+
+@(signature-forms ("advanced") advanced : signature enum mixed -> ListOf)
 
 @pre-defined-fun
 

--- a/htdp-doc/scribblings/htdp-langs/beginner-abbr.scrbl
+++ b/htdp-doc/scribblings/htdp-langs/beginner-abbr.scrbl
@@ -16,7 +16,8 @@
 
 @racketgrammar*+qq[
 #:literals (define define-struct lambda cond else if and or require lib planet
-            check-expect check-random check-within check-error check-satisfied)
+            check-expect check-random check-within check-error check-satisfied
+   	    : signature enum mixed -> ListOf)
 (name check-satisfied check-expect check-random check-within check-member-of check-range check-error require)
 [program (code:line def-or-expr #, @dots)]
 [def-or-expr definition
@@ -42,6 +43,15 @@
       boolean
       string
       character]
+[signature-declaration (: name signature-form)]
+[signature-form 
+	   (enum expr ...)
+	   (mixed signature-form ...)
+	   (signature-form ... -> signature-form)
+	   (ListOf signature-form)
+	   signature-variable
+	   expr]
+[signature-variable @#,elem{@racketvalfont{%}name}]
 ]
 
 @prim-nonterms[("beginner-abbr") define define-struct]
@@ -86,6 +96,11 @@ Abbreviations} level as they did in the @secref["beginner"] level.
             true false
              #:with-beginner-function-call #t]
 
+@; --------------------------------------------------
+
+@section[#:tag "beginner-abbr-signatures"]{Signatures}
+
+@(signature-forms ("beginner-abbr") define-struct : signature enum mixed -> ListOf)
 
 @; ----------------------------------------
 

--- a/htdp-doc/scribblings/htdp-langs/beginner.scrbl
+++ b/htdp-doc/scribblings/htdp-langs/beginner.scrbl
@@ -15,7 +15,8 @@
 
 @racketgrammar*+library[
 #:literals (define define-struct lambda cond else if and or require lib planet
-            check-expect check-random check-within check-error check-satisfied)
+            check-expect check-random check-within check-error check-satisfied
+            : signature enum mixed -> ListOf)
 (name check-satisfied check-expect check-random check-within check-member-of check-range check-error require)
 [program (code:line def-or-expr #, @dots)]
 [def-or-expr definition
@@ -38,7 +39,17 @@
       number
       boolean 
       string
-      character]
+      character
+      (signature signature-form)]
+[signature-declaration (: name signature-form)]
+[signature-form 
+	   (enum expr ...)
+	   (mixed signature-form ...)
+	   (signature-form ... -> signature-form)
+	   (ListOf signature-form)
+	   signature-variable
+	   expr]
+[signature-variable @#,elem{@racketvalfont{%}name}]
 ]
 
 @prim-nonterms[("beginner") define define-struct]
@@ -80,6 +91,12 @@ A quoted @racket[name] is a symbol. A symbol is a value, just like
              true false
              #:with-beginner-function-call #t
              )
+
+@; --------------------------------------------------
+
+@section[#:tag "beginner-signatures"]{Signatures}
+
+@(signature-forms ("beginner") define-struct : signature enum mixed -> ListOf)
 
 @; --------------------------------------------------
              

--- a/htdp-doc/scribblings/htdp-langs/intermediate-lambda.scrbl
+++ b/htdp-doc/scribblings/htdp-langs/intermediate-lambda.scrbl
@@ -13,7 +13,8 @@
 @racketgrammar*+qq[
 #:literals (define define-struct lambda λ cond else if and or require lib planet
             local let let* letrec time check-expect check-random
-	    check-within check-member-of check-range check-error check-satisfied)
+	    check-within check-member-of check-range check-error check-satisfied
+            : signature enum mixed -> ListOf)
 (expr check-satisfied check-expect check-random check-within check-member-of check-range check-error require)
 [program (code:line def-or-expr #, @dots)]
 [def-or-expr definition
@@ -44,7 +45,17 @@
       number
       boolean 
       string
-      character]
+      character
+      (signature signature-form)]
+[signature-declaration (: name signature-form)]
+[signature-form 
+	   (enum expr ...)
+	   (mixed signature-form ...)
+	   (signature-form ... -> signature-form)
+	   (ListOf signature-form)
+	   signature-variable
+	   expr]
+[signature-variable @#,elem{@racketvalfont{%}name}]
 ]
 
 @prim-nonterms[("intm-w-lambda") define define-struct]
@@ -125,6 +136,12 @@ level as they did in the @secref["intermediate"] level.
              #:with-beginner-function-call #f)
 
 @section[#:tag "intm-w-lambda-pre-defined"]{Pre-defined Functions}
+
+@; --------------------------------------------------
+
+@section[#:tag "intermediate-lambda-signatures"]{Signatures}
+
+@(signature-forms ("intermediate-lambda") define-struct : signature enum mixed -> ListOf)
 
 @pre-defined-fun
 

--- a/htdp-doc/scribblings/htdp-langs/intermediate.scrbl
+++ b/htdp-doc/scribblings/htdp-langs/intermediate.scrbl
@@ -13,7 +13,8 @@
 
 @racketgrammar*+qq[
 #:literals (define define-struct lambda cond else if and or require lib planet
-            local let let* letrec time check-expect check-random check-within check-error check-satisfied)
+            local let let* letrec time check-expect check-random check-within check-error check-satisfied
+   	    : signature enum mixed -> ListOf)
 (expr check-satisfied check-expect check-random check-within check-member-of check-range check-error require)
 [program (code:line def-or-expr #, @dots)]
 [def-or-expr definition
@@ -42,9 +43,19 @@
       number
       boolean 
       string
-      character]
+      character
+      (signature signature-form)]
 [expr-for-let (lambda (variable variable #, @dots) expr)
               expr]
+[signature-declaration (: name signature-form)]
+[signature-form 
+	   (enum expr ...)
+	   (mixed signature-form ...)
+	   (signature-form ... -> signature-form)
+	   (ListOf signature-form)
+	   signature-variable
+	   expr]
+[signature-variable @#,elem{@racketvalfont{%}name}]
 ]
 
 @prim-nonterms[("intermediate") define define-struct]
@@ -99,7 +110,11 @@ did in the @secref["beginner-abbr"] level.
                      #:with-beginner-function-call #t)
 
 
+@; --------------------------------------------------
 
+@section[#:tag "intermediate-signatures"]{Signatures}
+
+@(signature-forms ("intermediate") define-struct : signature enum mixed -> ListOf)
 
 @section[#:tag "intermediate-pre-defined" ]{Pre-defined Functions}
 

--- a/htdp-doc/teachpack/2htdp/scribblings/image.scrbl
+++ b/htdp-doc/teachpack/2htdp/scribblings/image.scrbl
@@ -2,7 +2,7 @@
 
 @(require (for-label racket/contract
                      2htdp/image
-                     (except-in lang/htdp-beginner posn make-posn posn? posn-x posn-y image?)
+                     (except-in lang/htdp-beginner posn make-posn posn? posn-x posn-y image? ->)
                      lang/posn
                      (except-in racket/gui/base make-color make-pen)
                      (only-in racket/base path-string?))

--- a/htdp-lib/lang/htdp-beginner-abbr.rkt
+++ b/htdp-lib/lang/htdp-beginner-abbr.rkt
@@ -49,12 +49,11 @@
          #%top-interaction
          empty 
          
-         ;  signature : -> mixed one-of predicate combined
-         ;  Number Real Rational Integer Natural Boolean True False String Symbol Char Empty-list Any
-         ;  cons-of
-         ;  Property
-         ;  check-property for-all ==> expect expect-within expect-member-of expect-range
-         )
+         signature : -> mixed enum predicate combined
+         Number Real Rational Integer Natural Boolean True False String Symbol Char Any
+         ListOf EmptyList
+         Property
+         check-property for-all ==> expect expect-within expect-member-of expect-range)
 
 ;; procedures:
 (provide-and-scribble

--- a/htdp-lib/lang/htdp-beginner.rkt
+++ b/htdp-lib/lang/htdp-beginner.rkt
@@ -53,12 +53,11 @@
          #%top-interaction
          empty
          
-         ;  signature : -> mixed one-of predicate combined
-         ;  Number Real Rational Integer Natural Boolean True False String Symbol Char Empty-list Any
-         ;  cons-of
-         ;  Property
-         ;  check-property for-all ==> expect expect-within expect-member-of expect-range
-         )
+         signature : -> mixed enum predicate combined
+         Number Real Rational Integer Natural Boolean True False String Symbol Char Any
+         ListOf EmptyList
+         Property
+         check-property for-all ==> expect expect-within expect-member-of expect-range)
  
 ;; procedures:
 (provide-and-scribble

--- a/htdp-lib/lang/htdp-intermediate-lambda.rkt
+++ b/htdp-lib/lang/htdp-intermediate-lambda.rkt
@@ -53,12 +53,11 @@
          #%top-interaction
          empty
          
-         ;  signature : -> mixed one-of predicate combined
-         ;  Number Real Rational Integer Natural Boolean True False String Symbol Char Empty-list Any
-         ;  cons-of
-         ;  Property
-         ;  check-property for-all ==> expect expect-within expect-member-of expect-range
-         )
+         signature : -> mixed enum predicate combined
+         Number Real Rational Integer Natural Boolean True False String Symbol Char Any
+         ConsOf ListOf EmptyList
+         Property
+         check-property for-all ==> expect expect-within expect-member-of expect-range)
 
 ;; procedures:
 (provide-and-scribble 

--- a/htdp-lib/lang/htdp-intermediate.rkt
+++ b/htdp-lib/lang/htdp-intermediate.rkt
@@ -55,12 +55,11 @@
          #%top-interaction
          empty 
          
-         ;  signature : -> mixed one-of predicate combined
-         ;  Number Real Rational Integer Natural Boolean True False String Symbol Char Empty-list Any
-         ;  cons-of
-         ;  Property 
-         ;  check-property for-all ==> expect expect-within expect-member-of expect-range
-         )
+         signature : -> mixed enum predicate combined
+         Number Real Rational Integer Natural Boolean True False String Symbol Char Any
+         ConsOf ListOf EmptyList
+         Property
+         check-property for-all ==> expect expect-within expect-member-of expect-range)
 
 
 (provide-and-scribble 

--- a/htdp-lib/lang/private/advanced-funs.rkt
+++ b/htdp-lib/lang/private/advanced-funs.rkt
@@ -1,11 +1,5 @@
 #lang at-exp scheme/base
   (require "teachprims.rkt"
-           (only-in "teach.rkt"
-                    Integer Number Rational Real Natural
-                    Boolean True False
-                    String Char Symbol
-                    EmptyList ConsOf
-                    Any)
            mzlib/etc
            mzlib/list
            mzlib/pretty
@@ -412,47 +406,4 @@
       (hash-eqv? heqv)
       ]
     })
-
-   ("Signatures"
-    @defthing[Number signature?]{
-    Signature for arbitrary numbers.
-    }
-    @defthing[Natural signature?]{
-    Signature for natural numbers.
-    }
-    @defthing[Integer signature?]{
-    Signature for integers.
-    }
-    @defthing[Rational signature?]{
-    Signature for rational numbers.
-    }
-    @defthing[Real signature?]{
-    Signature for real numbers.
-    }
-    @defthing[Boolean signature?]{
-    Signature for booleans.
-    }
-    @defthing[True signature?]{
-    Signature for just true.
-    }
-    @defthing[False signature?]{
-    Signature for just false.
-    }
-    @defthing[String signature?]{
-    Signature for strings.
-    }
-    @defthing[Char signature?]{
-    Signature for chararacters.
-    }
-    @defthing[Symbol signature?]{
-    Signature for symbols.
-    }
-    @defthing[EmptyList signature?]{
-    Signature for the empty list.
-    }
-    @defproc[(ConsOf [first-sig signature?] [rest-sig signature?]) signature?]{
-    Signature for a cons pair.
-    }
-    @defthing[Any signature?]{
-    Signature for any value.
-    }))
+)

--- a/htdp-lib/lang/private/beginner-funs.rkt
+++ b/htdp-lib/lang/private/beginner-funs.rkt
@@ -7,7 +7,13 @@
 (require mzlib/etc mzlib/list mzlib/math syntax/docprovide
          (for-syntax "firstorder.rkt")
          (for-syntax syntax/parse) 
-         (for-syntax racket/syntax))
+         (for-syntax racket/syntax)
+         (only-in "teach.rkt"
+                  Integer Number Rational Real Natural
+                  Boolean True False
+                  String Char Symbol
+                  EmptyList ConsOf
+                  Any))
 
 ;; Implements the procedures:
 (require "teachprims.rkt" "teach.rkt" lang/posn lang/imageeq "provide-and-scribble.rkt")
@@ -984,4 +990,48 @@
 }
   @defproc[((beginner-exit exit)) void]{
  Evaluating @racket[(exit)] terminates the running program. 
- }))
+ })
+
+ ("Signatures"
+    @defthing[Number signature?]{
+    Signature for arbitrary numbers.
+    }
+    @defthing[Natural signature?]{
+    Signature for natural numbers.
+    }
+    @defthing[Integer signature?]{
+    Signature for integers.
+    }
+    @defthing[Rational signature?]{
+    Signature for rational numbers.
+    }
+    @defthing[Real signature?]{
+    Signature for real numbers.
+    }
+    @defthing[Boolean signature?]{
+    Signature for booleans.
+    }
+    @defthing[True signature?]{
+    Signature for just true.
+    }
+    @defthing[False signature?]{
+    Signature for just false.
+    }
+    @defthing[String signature?]{
+    Signature for strings.
+    }
+    @defthing[Char signature?]{
+    Signature for chararacters.
+    }
+    @defthing[Symbol signature?]{
+    Signature for symbols.
+    }
+    @defthing[EmptyList signature?]{
+    Signature for the empty list.
+    }
+    @defproc[(ConsOf [first-sig signature?] [rest-sig signature?]) signature?]{
+    Signature for a cons pair.
+    }
+    @defthing[Any signature?]{
+    Signature for any value.
+    }))


### PR DESCRIPTION
Previously, they were only in ASL.

The technical change is straightforward.  The docs need some refactoring to avoid duplication.

As discussed with @mfelleisen and @dbp.