### PR TITLE
Bump setup-racket version to fix CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
         racket-variant: ["BC", "CS"]
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: Bogdanp/setup-racket@v1.1
+    - uses: actions/checkout@v3.5.3
+    - uses: Bogdanp/setup-racket@v1.10
       with:
         architecture: 'x64'
         distribution: 'minimal'


### PR DESCRIPTION
Bump workflow's `Bogdanp/setup-racket` action to v1.10 (Mar 2023).