### PR TITLE
Issue 203 take 2

### DIFF
--- a/htdp-lib/lang/run-teaching-program.rkt
+++ b/htdp-lib/lang/run-teaching-program.rkt
@@ -85,13 +85,13 @@
        (dynamic-wind
         void
         (lambda ()
-          (dynamic-require ''#,module-name #f))  ;; work around a bug in dynamic-require
+          (dynamic-require ''#,module-name #f)   ;; work around a bug in dynamic-require
+          (define test-submod `(submod '#,module-name test))
+          (when (module-declared? test-submod)
+            (dynamic-require test-submod #f)))
         (lambda ()
           (unless done-already?
             (set! done-already? #t)
-            #,(if enable-testing?
-                  #'(test)
-                  #'(begin))
             (current-namespace (module->namespace ''#,module-name))))))))
 
 ;; take all of the body expressions from the port


### PR DESCRIPTION
This tries a different approach to issue #203 that doesn't introduce the bug identified in #205. 

It may be, however, that simply not inserting `(test)` is the right move if the `dynamic-require` in the body of `make-dynamic-requirer` already is going to run the tests without any intervention at this level, which would mean yet a slightly different fix is the right one.

Meanwhile, this at least passes the two test cases.