### PR TITLE
Remove the `for-each` document from ISL

### DIFF
--- a/htdp-lib/lang/private/intermediate-plus.rkt
+++ b/htdp-lib/lang/private/intermediate-plus.rkt
@@ -169,11 +169,11 @@
  @interaction[#:eval ev-isl (map add-and-multiply (list 3 -4 2/5) '(1 2 3))]
 }
   @defproc[(for-each [f (any ... -> any)] [l (listof any)] ...) void?]{
- Applies a function to each item on one or more lists for effect only:
- @codeblock{(for-each f (list x-1 ... x-n)) = (begin (f x-1) ... (f x-n))}
- @interaction[#:eval (asl-eval)
-              (for-each (lambda (x) (begin (display x) (newline))) '(1 2 3))
-              ]
+ Applies a function to each item on one or more lists for effect only.
+
+ Although the @emph{Intermediate Student with Lambda} provides
+ the @racket[for-each] function, it is intended to be used
+ in the @secref["advanced"] level.
 }
   @defproc[((intermediate-filter filter) [p? (X -> boolean)] [l (listof X)]) (listof X)]{
  Constructs a list from all those items on a list for which the predicate holds.


### PR DESCRIPTION
This PR removes the documentation of `for-each` from ISL+, because it is actually part of ASL.

The new ISL+ `for-each` doc points to ASL.