### PR TITLE
Correctly count succeeded tests.

### DIFF
--- a/htdp-doc/test-engine/test-engine.scrbl
+++ b/htdp-doc/test-engine/test-engine.scrbl
@@ -153,14 +153,18 @@ structure called a @italic{test object}.  There is always a current
 test object associated with the current namespace.
 
 @defstruct*[test-object
-            ((tests (listof (-> any)))
+            ((tests (listof (-> boolean?)))
+             (successful-tests (listof (-> boolean?)))
              (failed-checks (listof failed-check?))
              (signature-violations (listof signature-violation?)))
 	     #:omit-constructor]{
-The three components of a @racket[test-object] are all in reverse order:
+The four components of a @racket[test-object] are all in reverse order:
 
 The first one is the list of tests (each represented by a thunk), the
-others are failed checks and signature violations, respectively.
+others are succeeded tests, failed checks and signature violations, respectively.
+
+The thunks are expected to always run to completion.  They shouöd
+return @racket[#t] upon success, and @racket[#f] upon failure.
 }
 
 @defproc[(empty-test-object) test-object?]{
@@ -179,7 +183,7 @@ operating on it: These will automatically initialize as necessary.
 Use this function to reset the current test object.
 }
 
-@defproc[(add-test! [thunk (-> any)])  any]{
+@defproc[(add-test! [thunk (-> boolean?)])  any]{
 Register a test, represented by a thunk.  The thunk, when called, is
 expected to call @racket[add-failed-check!] and
 @racket[add-signature-violation!] as appropriate.

--- a/htdp-lib/test-engine/test-markup.rkt
+++ b/htdp-lib/test-engine/test-markup.rkt
@@ -68,7 +68,7 @@
          empty-markup]
         [(and (null? (test-object-failed-checks test-object))
               (null? (test-object-signature-violations test-object)))
-         (let ((count (length (test-object-tests test-object))))
+         (let ((count (length (test-object-successful-tests test-object))))
            (case count
              [(0) (string-constant test-engine-0-tests-passed)]
              [(1) (string-constant test-engine-1-test-passed)]


### PR DESCRIPTION
Fixes #212.

The test-engine previously assumed that, if there were no errors, the number of succeeded tests would be equal to the total number of tests.

This is of course wrong when the tests didn't run.  As this can happen now after the previous round of fixes in test execution, properly count succeeded tests.

To that end, document that we're expecting test thunks to return booleans.