### PR TITLE
Added "exponentiation" to the description of expt

### DIFF
--- a/htdp-lib/lang/private/beginner-funs.rkt
+++ b/htdp-lib/lang/private/beginner-funs.rkt
@@ -200,7 +200,7 @@
   
   ;; exponents and logarithms 
   @defproc[(expt [x number][y number]) number]{
- Computes the power of the first to the second number.
+ Computes the power of the first to the second number, which is to say, exponentiation.
  @interaction[#:eval (bsl) (expt 16 1/2) (expt 3 -4)]
 }
   @defproc[(exp [x number]) number]{


### PR DESCRIPTION
Right now, if you Ctrl+f for the word, you can't find the function in the docs.