### PR TITLE
Documentation: Fix typo in `check-range` example

### DIFF
--- a/htdp-doc/scribblings/htdp-langs/prim-ops.rkt
+++ b/htdp-doc/scribblings/htdp-langs/prim-ops.rkt
@@ -667,7 +667,7 @@ functions that compute inexact numbers:
   (slope f (- x EPSILON) (+ x EPSILON)))
 
 ;; [Real -> Real] Real Real -> Real 
-(define (slope-of f left right)
+(define (slope f left right)
   (/ (- (f right) (f left))
      2 EPSILON))
 


### PR DESCRIPTION
This example now passes the `check-range`, but it's still problematic because it uses first-class function despite being displayed on the `Beginning Student` page.