### PR TITLE
Fix the stack trace of `check-expect` forms

### DIFF
--- a/htdp-lib/test-engine/racket-tests.rkt
+++ b/htdp-lib/test-engine/racket-tests.rkt
@@ -26,10 +26,10 @@
          simple-tree-text-markup/construct
          simple-tree-text-markup/port)
 
-(define INEXACT-NUMBERS-FMT
-  "check-expect cannot compare inexact numbers. Try (check-within test ~a range).")
+(define CHECK-EXPECT-INEXACT-NUMBERS-FMT
+  "check-expect: cannot compare inexact numbers, but the second argument is ~a. Try (check-within test ~a error-range).")
 (define FUNCTION-FMT
-  "check-expect cannot compare functions.")
+  "check-expect: cannot compare functions, but the second argument ~a is a function.")
 (define SATISFIED-FMT
   "check-satisfied: expects function of one argument in second position. Given ~a")
 (define CHECK-ERROR-STR-FMT
@@ -109,9 +109,9 @@
 
 (define (do-check-expect test expected src)
   (error-check (lambda (v) (if (number? v) (exact? v) #t))
-               expected INEXACT-NUMBERS-FMT #t)
+               expected INEXACT-NUMBERS-FMT #t (list expected expected))
   (error-check (lambda (v) (not (procedure? v)))
-               expected FUNCTION-FMT #f)
+               expected FUNCTION-FMT #t)
   (execute-test
    src
    (lambda ()
@@ -312,10 +312,10 @@
            (not-range src val min max))))
    (make-exn->unexpected-error src (format "[~a, ~a]" min max))))
 
-(define (error-check pred? actual fmt fmt-act?)
+(define (error-check pred? actual fmt fmt-act? [fmt-args (list actual)])
   (unless (pred? actual)
     (raise
-     (make-exn:fail:contract (if fmt-act? (format fmt actual) fmt)
+     (make-exn:fail:contract (if fmt-act? (apply format fmt fmt-args) fmt)
                              (current-continuation-marks)))))
 
 

--- a/htdp-lib/test-engine/racket-tests.rkt
+++ b/htdp-lib/test-engine/racket-tests.rkt
@@ -35,9 +35,9 @@
 (define CHECK-ERROR-STR-FMT
   "check-error: expects a string (the expected error message) for the second argument. Given ~s")
 (define CHECK-WITHIN-INEXACT-FMT
-  "check-within: expects an inexact number for the range. ~a is not inexact.")
+  "check-within: expects an inexact number for the range. ~s is not inexact.")
 (define CHECK-WITHIN-FUNCTION-FMT
-  "check-within cannot compare functions.")
+  "check-within cannot compare functions, but the second argument is ~a.")
 (define LIST-FMT
   "check-member-of: expects a list for the second argument (the possible outcomes). Given ~s")
 (define CHECK-MEMBER-OF-FUNCTION-FMT
@@ -217,7 +217,7 @@
 
 (define (do-check-within test expected within src)
   (error-check number? within CHECK-WITHIN-INEXACT-FMT #t)
-  (error-check (lambda (v) (not (procedure? v))) expected CHECK-WITHIN-FUNCTION-FMT #f)
+  (error-check (lambda (v) (not (procedure? v))) expected CHECK-WITHIN-FUNCTION-FMT #t)
   (execute-test
    src
    (lambda ()

--- a/htdp-lib/test-engine/racket-tests.rkt
+++ b/htdp-lib/test-engine/racket-tests.rkt
@@ -27,7 +27,7 @@
          simple-tree-text-markup/port)
 
 (define CHECK-EXPECT-INEXACT-NUMBERS-FMT
-  "check-expect: cannot compare inexact numbers, but the second argument is ~a. Try (check-within test ~a error-range).")
+  "check-expect: cannot compare inexact numbers, but the second argument is ~a.")
 (define FUNCTION-FMT
   "check-expect: cannot compare functions, but the second argument ~a is a function.")
 ;; No fix were available; don't suggest anything.
@@ -112,7 +112,7 @@
 
 (define (do-check-expect test expected src)
   (error-check (lambda (v) (if (number? v) (exact? v) #t))
-               expected CHECK-EXPECT-INEXACT-NUMBERS-FMT #t (list expected expected))
+               expected CHECK-EXPECT-INEXACT-NUMBERS-FMT #t)
   (error-check (lambda (v) (not (procedure? v)))
                expected FUNCTION-FMT #t)
   (execute-test
@@ -315,10 +315,10 @@
            (not-range src val min max))))
    (make-exn->unexpected-error src (format "[~a, ~a]" min max))))
 
-(define (error-check pred? actual fmt fmt-act? [fmt-args (list actual)])
+(define (error-check pred? actual fmt fmt-act?)
   (unless (pred? actual)
     (raise
-     (make-exn:fail:contract (if fmt-act? (apply format fmt fmt-args) fmt)
+     (make-exn:fail:contract (if fmt-act? (format fmt actual) fmt)
                              (current-continuation-marks)))))
 
 

--- a/htdp-lib/test-engine/racket-tests.rkt
+++ b/htdp-lib/test-engine/racket-tests.rkt
@@ -30,6 +30,9 @@
   "check-expect: cannot compare inexact numbers, but the second argument is ~a. Try (check-within test ~a error-range).")
 (define FUNCTION-FMT
   "check-expect: cannot compare functions, but the second argument ~a is a function.")
+;; No fix were available; don't suggest anything.
+(define CHECK-RANDOM-INEXACT-NUMBERS-FMT
+  "check-random: cannot compare inexact numbers, but the second argument is ~a.")
 (define SATISFIED-FMT
   "check-satisfied: expects function of one argument in second position. Given ~a")
 (define CHECK-ERROR-STR-FMT
@@ -109,7 +112,7 @@
 
 (define (do-check-expect test expected src)
   (error-check (lambda (v) (if (number? v) (exact? v) #t))
-               expected INEXACT-NUMBERS-FMT #t (list expected expected))
+               expected CHECK-EXPECT-INEXACT-NUMBERS-FMT #t (list expected expected))
   (error-check (lambda (v) (not (procedure? v)))
                expected FUNCTION-FMT #t)
   (execute-test
@@ -136,7 +139,7 @@
                           (random-seed k)
                           (expected-thunk))))
       (error-check (lambda (v) (if (number? v) (exact? v) #t))
-                   expected INEXACT-NUMBERS-FMT #t)
+                   expected CHECK-RANDOM-INEXACT-NUMBERS-FMT #t)
       (execute-test
        src
        (lambda ()

--- a/htdp-lib/test-engine/syntax.rkt
+++ b/htdp-lib/test-engine/syntax.rkt
@@ -60,11 +60,14 @@
                       (['stepper-hint hint-tag]
                        ['stepper-hide-reduction #t]
                        ['stepper-use-val-as-final #t])
-                      (quasisyntax/loc stx
-                        (#,checker-proc-stx
-                         (lambda () #,test-expr-checked-for-syntax-error)
-                         #,@embedded-stxes
-                         #,src-info)))))
+                      (syntax-property
+                       (quasisyntax/loc stx
+                         (#,checker-proc-stx
+                          (lambda () #,test-expr-checked-for-syntax-error)
+                          #,@embedded-stxes
+                          #,src-info))
+                       'errortrace:annotate
+                       #t))))
              'stepper-skipto
              (append skipto/cdr
                      skipto/second ;; outer lambda

--- a/htdp-test/tests/stepper/test-cases.rkt
+++ b/htdp-test/tests/stepper/test-cases.rkt
@@ -1144,7 +1144,7 @@
   (t 'check-expect-err m:upto-int/lam
      (check-expect 0 (sqrt 2))
      :: (check-expect 0 {(sqrt 2)}) -> (check-expect 0 {1.4142135623730951})
-     :: error: "check-expect cannot compare inexact numbers")
+     :: error: "check-expect: cannot compare inexact numbers")
 
   (t1 'check-within
       m:upto-int/lam


### PR DESCRIPTION
In #lang SLs, `check-expect` and similar forms are not annotated by errortrace.
This PR adds the `errortrace:annotate` syntax property to request for annotation.

Before:

```racket
#lang htdp/isl+
;; error at test-engine/racket-tests.rkt:XXX:XX
(check-expect 0 zero?)
;; check failure at lang/private/teachprims.rkt:XXX:XX
(check-expect zero? 0)
```

After: error at line 3, column 0 and line 5, column 0.

-----

In addition to stack trace fixes, this PR refines and fixes somes `check-`form error messages:
- `check-random` and `check-expect` should NOT have identical error messages.
- Have `check-expect` messages refer to "the second argument" like other `check-`forms.
- Format the third argument of `check-within` with `~s` instead of `~a` for otherwise strings like `"NNN.mm"` would be printed like numbers (i.e. just `NNN.mm`).