### PR TITLE
Only respond to new `check-expect`s in REPL

### DIFF
--- a/htdp-lib/htdp/bsl/runtime.rkt
+++ b/htdp-lib/htdp/bsl/runtime.rkt
@@ -15,7 +15,7 @@
          racket/class
          (only-in test-engine/test-markup get-rewritten-error-message-parameter render-value-parameter)
          (only-in test-engine/syntax report-signature-violation! test)
-         (only-in test-engine/test-engine test-object-copy current-test-object test-object=?)
+         (only-in test-engine/test-engine initialize-test-object! test-object-copy current-test-object test-object=?)
          (only-in deinprogramm/signature/signature
                   signature? signature-name
                   signature-violation-proc)
@@ -206,6 +206,8 @@
     (current-eval
      (let ((old-eval (current-eval)))
        (lambda args
+         (when interaction?
+           (initialize-test-object!))
          (let ((test-object (test-object-copy (current-test-object))))
            (dynamic-wind
              void


### PR DESCRIPTION
#lang SLs and menu-based SLs use different test engine UIs:

- #lang SLs: all test results go to REPL
- menu-based SLs: reports go to a separate window

Consequently, when a new `check-expect` is executed from REPL, I think #lang SLs should only respond to it rather than printing the outcome of all existing tests. In contrast, it makes sense for menu-based SLs to retain its current behavior.

This PR changes #lang SLs by clearing all tests before executing REPL inputs. It does not affect menu-based SLs.

Example program:

    #lang htdp/bsl
    (check-expect (+ 2 3) 5)
    (check-expect (+ 2 3) 6)

Old behavior:

    Welcome to DrRacket!
    Ran 2 tests.
    1 of the 2 tests failed.

    > (check-expect (* 2 3) 6)
    Ran 3 tests.
    1 of the 3 tests failed.
                                  ;;        no good
    Check failures:               ;;      ↙
            Actual value 5 differs from 6, the expected value.
    at line 3, column 0

    > (check-expect (error 'oops) 123)
    Ran 4 tests.
    2 of the 4 tests failed.
    ...

New behavior:

    #lang htdp/bsl
    (check-expect (+ 2 3) 5)
    (check-expect (+ 2 3) 6)

    Welcome to DrRacket!
    Ran 2 tests.
    1 of the 2 tests failed.

    > (check-expect (* 2 3) 6)
    The test passed!

    > (check-expect (error 'oops) 123)
    Ran 1 test.
    0 tests passed.
    ...
