### PR TITLE
Partly revert d53a197 & 36fc539 to workaround #233

### DIFF
--- a/htdp-lib/2htdp/universe.rkt
+++ b/htdp-lib/2htdp/universe.rkt
@@ -442,5 +442,11 @@
          (with-handlers ([exn:fail? (lambda (e) (channel-put obj-or-exn:ch e))])
            (channel-put obj-or-exn:ch (o))))))
     (match (channel-get obj-or-exn:ch)
-      [(? exn:fail? e) (raise e)]
+      [(? exn:fail? e)
+       (raise (if (regexp-match? #rx"check-with" (exn-message e))
+                  ;; Report big-bang check-with errors using the big-bang's stack frames
+                  ;; instead of esp/thd's stacks
+                  (make-exn:fail:contract (exn-message e)
+                                          (current-continuation-marks))
+                  e))]
       [obj (send obj last)])))

--- a/htdp-lib/2htdp/universe.rkt
+++ b/htdp-lib/2htdp/universe.rkt
@@ -276,7 +276,7 @@
          [else
           (syntax-property 
            (stepper-syntax-property
-            (quasisyntax/loc stx (send [((new-world (if #,rec? aworld% world%)) w #,@args)] last))
+            (quasisyntax/loc stx (run-it ((new-world (if #,rec? aworld% world%)) w #,@args)))
             'stepper-skip-completely #t)
            'disappeared-use (map (lambda (x) (car (syntax->list x))) dom))]))]))
 
@@ -411,7 +411,7 @@
           (raise-syntax-error #f "expects a on-msg clause, but found none" stx)]
          [else ; (and (memq #'on-new dom) (memq #'on-msg dom))
           (syntax-property 
-           (quasisyntax/loc stx (send [((new-universe universe%) u #,@args)] last))
+           (quasisyntax/loc stx (run-it ((new-universe universe%) u #,@args)))
            'disappeared-use (map (lambda (x) (car (syntax->list x))) dom))]))]))
 
 ;                                          
@@ -430,7 +430,7 @@
 ;                                          
 ;                                          
 
-#;
+;; (-> Object) -> Any
 (define (run-it o)
   (define esp (make-eventspace))
   (define thd (eventspace-handler-thread esp))

--- a/htdp-test/info.rkt
+++ b/htdp-test/info.rkt
@@ -9,7 +9,6 @@
                      "redex-lib"
                      "racket-index"
                      "scheme-lib"
-                     "srfi-lite-lib"
                      "compatibility-lib"
                      "gui-lib"
                      "racket-test"

--- a/htdp-test/tests/stepper/automatic-tests.rkt
+++ b/htdp-test/tests/stepper/automatic-tests.rkt
@@ -33,8 +33,7 @@
   '(local-struct/ilam
     local-struct/i
     begin-let-bug
-    qq-splice
-    big-bang))
+    qq-splice))
 
 ;; this test anticipates the implementation of the stepper
 ;; for check-random, which is not yet implemented

--- a/htdp-test/tests/stepper/test-engine.rkt
+++ b/htdp-test/tests/stepper/test-engine.rkt
@@ -12,6 +12,7 @@
          racket/contract
          racket/file
          mzlib/pconvert-prop ;; so it can be attached.
+         racket/gui/base ;; stepper big-bang tests need them attached
          test-engine/test-markup
          lang/private/rewrite-error-message
          test-engine/test-engine
@@ -196,6 +197,7 @@
   (parameterize ([current-namespace (make-base-namespace)])
     (namespace-attach-module orig-namespace 'mzlib/pconvert-prop)
     (namespace-attach-module orig-namespace 'racket/class)
+    (namespace-attach-module orig-namespace 'racket/gui/base)
     (namespace-attach-module orig-namespace 'test-engine/racket-tests)
     (thunk)))
 


### PR DESCRIPTION
A more appropriate fix should be applied in the future.

To workaround #233, this partly reverts commits

- "highlight universe when set-up fails at run-time". d53a1978acd16f16c29746b9b68e096be955377b
- "fix resource administration in run and launch-many-worlds". 36fc53949a8bd3df5ffca2ecce3f3a3b2b078a63

Otherwise, when the object `[((new-world (if #,rec? aworld% world%)) w #,@args)]` and `[((new-universe universe%) u #,@args)]` are created in the main thread, the continuation marks of the stepper are somehow broken.

The two follow up commits forward the `check-with` exceptions from `(o)` in `esp`/`thd` to the main thread and repackages it with `big-bang`'s stack frames.