### PR TITLE
Do not grab syntax errors in `check-error`

### DIFF
--- a/htdp-lib/test-engine/racket-tests.rkt
+++ b/htdp-lib/test-engine/racket-tests.rkt
@@ -253,7 +253,9 @@
   (execute-test
    src
    (lambda ()
-     (with-handlers ([exn:fail?
+     (with-handlers ([(lambda (exn)
+                        (and (exn:fail? exn)
+                             (not (exn:fail:syntax? exn))))
                       (lambda (exn)
                         (let ((msg (get-rewritten-error-message exn)))
                           (if (equal? msg error)


### PR DESCRIPTION
In `check-error` all errors are captured and checked. As a result, the following are expressible in *SLs:

```racket
;; Current behavior: all three tests pass
(check-error x "x: this variable is not defined")
(check-error define "define: expected an open parenthesis before define, but found none")

;; In BSL
(check-error (1) "function call: expected a function after the open parenthesis, but found a number")

;; This PR:
check-error encountered the following error instead of the expected message
```

I think syntactically incorrect expressions in `check-error` should fail when they run, because when an expression contains syntax errors, it means that something is wildly off the road. No syntax errors should be "checked" and "passed".

I think it's an accident that `check-error` can capture syntax errors. This is only because syntax errors are necessarily delayed until runtime to allow running unfinished programs (1dea4eb1d994d03ce4acb05fc8a726b74ca96603).

Checking syntax errors also causes problem outside DrRacket (https://github.com/racket/htdp/issues/242#issuecomment-2652742521) because the messages are different. I suspect that this is caused by different `error-display-handler`s.
