### PR TITLE
Fix universe signature tick-handler signature, 3rd form

### DIFF
--- a/htdp-doc/teachpack/2htdp/scribblings/universe.scrbl
+++ b/htdp-doc/teachpack/2htdp/scribblings/universe.scrbl
@@ -1344,7 +1344,7 @@ optional handlers:
 }
 
 @defform/none[#:literals (on-tick)
-              (on-tick tick-expr rate-expr)
+              (on-tick tick-expr rate-expr limit-expr)
               #:contracts
               ([tick-expr (-> (unsyntax @tech{UniverseState}) (or/c (unsyntax @tech{UniverseState}) bundle?))]
                [rate-expr (and/c real? positive?)]


### PR DESCRIPTION
 The signature of 3rd form of tick-handler in universe was inconsistent with the rest of the documentation and program behavior.