### PR TITLE
Remove Racket BC from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,15 @@ on: [push, pull_request]
 
 jobs:
   build-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        racket-variant: ["BC", "CS"]
+        racket-variant: ["CS"]
 
     steps:
-    - uses: actions/checkout@v3.5.3
-    - uses: Bogdanp/setup-racket@v1.10
+    - uses: actions/checkout@v4.3.0
+    - uses: Bogdanp/setup-racket@v1.14
       with:
         architecture: 'x64'
         distribution: 'full'


### PR DESCRIPTION
Racket no longer distributes prebuilt BC binaries. Also bump the version of the Ubuntu runner and some GHA versions