### PR TITLE
Fix intermittent universe-restart.rkt DrDr failure

### DIFF
--- a/htdp-lib/2htdp/private/world.rkt
+++ b/htdp-lib/2htdp/private/world.rkt
@@ -132,9 +132,10 @@
               (thread (RECEIVE in))))))
       
       (define/private (broadcast msg)
-        (when *out* 
+        (when *out*
           (check-result 'send sexp? "Sexp expected; given ~e\n" msg)
-          (tcp-send *out* msg)))
+          (with-handlers ([exn:fail:network? (lambda (e) (set! *out* #f))])
+            (tcp-send *out* msg))))
       
       ;; -----------------------------------------------------------------------
       (field


### PR DESCRIPTION
Handle network errors in `broadcast` when universe drops a world.

When a universe drops a world by closing the TCP connection, subsequent attempts by the world to send messages would raise a "Broken pipe" error. This caused intermittent test failures in `universe-restart.rkt`.

The fix catches `exn:fail:network?` in the `broadcast` function and sets `*out*` to `#f`, preventing the exception from propagating.

Example failure: https://drdr.racket-lang.org/71877/racket/share/pkgs/htdp-test/2htdp/tests/universe-restart.rkt