### PR TITLE
Bump errortrace dependency

### DIFF
--- a/htdp-lib/info.rkt
+++ b/htdp-lib/info.rkt
@@ -7,7 +7,7 @@
     "compatibility-lib"
     "draw-lib"
     ("drracket-plugin-lib" #:version "1.1")
-    "errortrace-lib"
+    ("errortrace-lib" #:version "1.6")
     "html-lib"
     "images-gui-lib"
     "images-lib"


### PR DESCRIPTION
8cb765d0 needs errortrace-lib 1.6. Although they are all in `main-distribution`, it's better to make the dependency explicit.