### PR TITLE
Improve Posn documentation

### DIFF
--- a/htdp-lib/lang/private/beginner-funs.rkt
+++ b/htdp-lib/lang/private/beginner-funs.rkt
@@ -21,7 +21,10 @@
 (define-syntax (provide-and-wrap stx)
   (syntax-parse stx 
     ; (defproc (name args ...) range w ...)
-    [(provide-and-wrap wrap doc-tag:id requires (title df ...) ...)
+    [(provide-and-wrap wrap doc-tag:id requires
+       (title (~optional (~seq #:description description)
+                         #:defaults ([description #'#f]))
+              df ...) ...)
      (let* ((defs (map syntax->list (syntax->list #'((df ...) ...))))
             (names (map extract-names defs))
             (tmps  (map generate-temporaries names))
@@ -55,10 +58,12 @@
              ;; one that makes definitions first-order 
              (module+ with-wrapper 
                (wrap f internal-name) ... ...
-               (provide-and-scribble doc-tag requires (title dg ...) ...))
+               (provide-and-scribble doc-tag requires
+                 (title #:description description dg ...) ...))
              ;; and one that doesn't
              (module+ without-wrapper 
-               (provide-and-scribble doc-tag requires (title df ...) ...)))))]))
+               (provide-and-scribble doc-tag requires
+                 (title #:description description df ...) ...)))))]))
 
 ;; MF: this is now an ugly kludge, left over from my original conversion of Matthew's docs for *SL
 (define-syntax (in-rator-position-only stx)
@@ -100,7 +105,7 @@
         
  (define one (list 1))
         
- (define q (make-posn "bye" 2))
+ (define q (make-posn 1 2))
  (define p (make-posn 2 -3))
         
  (define a (list (list 'a 22) (list 'b 8) (list 'c 70)))
@@ -665,10 +670,13 @@
   )
  
  ("Posns"
+  #:description @para{A posn represents a position using two coordinates: the distance from the
+  left margin, called the @italic{x-coordinate}, and the distance from the top margin, called the
+  @italic{y-coordinate}.}
   ; @defproc[(posn) signature]{Signature for posns.}
   @defproc[(make-posn [x any/c][y any/c]) posn]{
  Constructs a posn from two arbitrary values.
- @interaction[#:eval (bsl) (make-posn 3 3) (make-posn "hello" #true)]
+ @interaction[#:eval (bsl) (make-posn 3 3) (make-posn 3 4)]
 }
   @defproc[(posn? [x any/c]) boolean?]{
  Determines if its input is a posn.

--- a/htdp-lib/lang/private/beginner-funs.rkt
+++ b/htdp-lib/lang/private/beginner-funs.rkt
@@ -670,9 +670,13 @@
   )
  
  ("Posns"
-  #:description @para{A posn represents a position using two coordinates: the distance from the
-  left margin, called the @italic{x-coordinate}, and the distance from the top margin, called the
-  @italic{y-coordinate}.}
+  #:description
+  (list
+   @para{A @italic{Posn} is a structure:}
+   @racketblock[(make-posn Number Number)]
+   @para{@bold{interpretation} @racket[(make-posn x y)] represents a position using two coordinates:
+   the distance from the left margin, called the @italic{x-coordinate}, and the distance from the
+   top margin, called the @italic{y-coordinate}.})
   ; @defproc[(posn) signature]{Signature for posns.}
   @defproc[(make-posn [x any/c][y any/c]) posn]{
  Constructs a posn from two arbitrary values.

--- a/htdp-lib/lang/private/beginner-funs.rkt
+++ b/htdp-lib/lang/private/beginner-funs.rkt
@@ -105,7 +105,7 @@
         
  (define one (list 1))
         
- (define q (make-posn 1 2))
+ (define q (make-posn "bye" 2))
  (define p (make-posn 2 -3))
         
  (define a (list (list 'a 22) (list 'b 8) (list 'c 70)))
@@ -676,7 +676,7 @@
   ; @defproc[(posn) signature]{Signature for posns.}
   @defproc[(make-posn [x any/c][y any/c]) posn]{
  Constructs a posn from two arbitrary values.
- @interaction[#:eval (bsl) (make-posn 3 3) (make-posn 3 4)]
+ @interaction[#:eval (bsl) (make-posn 3 3) (make-posn "hello" #true)]
 }
   @defproc[(posn? [x any/c]) boolean?]{
  Determines if its input is a posn.

--- a/htdp-lib/lang/private/provide-and-scribble.rkt
+++ b/htdp-lib/lang/private/provide-and-scribble.rkt
@@ -67,14 +67,16 @@ tests to run:
         [(all-from tag:id path label:id)
          (define-values (a p) (provide-all-from #'path #'label #'tag #'()))
          (values (cons a add-docs-and-provide) (append (syntax->list p) provides))]
-        [(title df ...)
+        [(title (~optional (~seq #:description description)
+                           #:defaults ([description #'#f]))
+                df ...)
          (define name* (extract-names (syntax->list #'(df ...))))
          (define exnm* (extract-external-name name*))
          (define defs* (rewrite-defs (syntax->list #'(df ...)) exnm*))
          (values (cons (lambda ()  ;; delay the syntax creation until add-sections is set
                          (with-syntax ([(ex ...) exnm*]
                                        [(df ...) defs*])
-                           #`(#,*add title (list (cons #'ex df) ...))))
+                           #`(#,*add title description (list (cons #'ex df) ...))))
                        add-docs-and-provide)
                  (cons #`(provide #,@(optional-rename-out name*))
                        provides))])))
@@ -127,7 +129,7 @@ tests to run:
               ;; so I went with dynamic-require. Argh. 
               ;; ******************************************************************
               #`(for ((s ((dynamic-require '(submod path nested-tag ... label) 'docs) #'f ...)))
-                  (#,*add (car s) (cadr s))))
+                  (#,*add (car s) (cadr s) (caddr s))))
             #`(;; import from path with prefix, exclude f ...
                (require (prefix-in prefix (except-in (submod path nested-tag ...) f ...)))
                ;; export the bindings without prefix 
@@ -153,7 +155,7 @@ tests to run:
                          #,requires
                          ;; -----------------------------------------------------------------------
                          ;; Section  = [Listof (cons Identifier Doc)]
-                         ;; Sections = [Listof (list Title Section)]
+                         ;; Sections = [Listof (list Title (U #f Block) Section)]
                          (provide 
                           ;; Identifier ... *-> Sections
                           ;; retrieve the document without the specified identifiers
@@ -172,12 +174,15 @@ tests to run:
                                [else 
                                 (define section1 (car s))
                                 (define others (render-sections (cdr s)))
-                                (define-values (section-title stuff) (apply values section1))
+                                (define-values (section-title description stuff)
+                                  (apply values section1))
                                 (define sorted 
                                   (sort stuff string<=? #:key (compose symbol->string syntax-e car)))
                                 (define typed (for/list ((s sorted)) (re-context c (car s) (cdr s))))
                                 (cons @section[#:tag-prefix p]{@section-title}
-                                      (cons typed others))])))
+                                      (if description
+                                          (cons description (cons typed others))
+                                          (cons typed others)))])))
                          
                          (define (re-context c id defproc)
                            (defproc c))
@@ -187,26 +192,30 @@ tests to run:
                            (define (is-exception i)
                              (memf (lambda (j) (eq? (syntax-e j) (syntax-e i))) exceptions))
                            (for/list ((s *sections))
-                             (define sectn (second s))
+                             (define sectn (third s))
                              (define clean (filter (lambda (i) (not (is-exception (car i)))) sectn))
-                              (list (first s) clean)))
+                             (list (first s) (second s) clean)))
                          ;; 
                          ;; state variable: Sections
                          (define *sections '())
-                         ;; String Section -> Void 
+                         ;; String (U #f Block) Section -> Void
                          ;; add _scontent_ section to *sections in the doc submodule 
-                         (define (#,*add stitle scontent)
+                         (define (#,*add stitle sdescription scontent)
                            (define exists #f)
                            (define sections
                              (for/list ((s *sections))
                                (cond
                                  [(string=? (first s) stitle) 
                                   (set! exists #t)
-                                  (list stitle (append (second s) scontent))]
+                                  (list stitle
+                                        (or (second s) sdescription)
+                                        (append (third s) scontent))]
                                  [else s])))
                            (if exists
                                (set! *sections sections)
-                               (set! *sections (append sections (list (list stitle scontent))))))
+                               (set! *sections
+                                     (append sections
+                                             (list (list stitle sdescription scontent))))))
                          
                          #,@(map (lambda (adp) (adp)) (reverse add-docs-and-provide)))
                 p* ...)])))
@@ -227,4 +236,3 @@ tests to run:
            [(internal:id external:id) #'(rename-out (internal external))]
            [name:id #'name]))
        lon))
-

--- a/htdp-lib/lang/private/provide-and-scribble.rkt
+++ b/htdp-lib/lang/private/provide-and-scribble.rkt
@@ -155,7 +155,8 @@ tests to run:
                          #,requires
                          ;; -----------------------------------------------------------------------
                          ;; Section  = [Listof (cons Identifier Doc)]
-                         ;; Sections = [Listof (list Title (U #f Block) Section)]
+                         ;; Description = (U #f Block [Listof Block])
+                         ;; Sections = [Listof (list Title Description Section)]
                          (provide 
                           ;; Identifier ... *-> Sections
                           ;; retrieve the document without the specified identifiers
@@ -179,10 +180,13 @@ tests to run:
                                 (define sorted 
                                   (sort stuff string<=? #:key (compose symbol->string syntax-e car)))
                                 (define typed (for/list ((s sorted)) (re-context c (car s) (cdr s))))
+                                (define description-blocks
+                                  (cond
+                                    [(not description) '()]
+                                    [(list? description) description]
+                                    [else (list description)]))
                                 (cons @section[#:tag-prefix p]{@section-title}
-                                      (if description
-                                          (cons description (cons typed others))
-                                          (cons typed others)))])))
+                                      (append description-blocks (cons typed others)))])))
                          
                          (define (re-context c id defproc)
                            (defproc c))
@@ -198,7 +202,7 @@ tests to run:
                          ;; 
                          ;; state variable: Sections
                          (define *sections '())
-                         ;; String (U #f Block) Section -> Void
+                         ;; String Description Section -> Void
                          ;; add _scontent_ section to *sections in the doc submodule 
                          (define (#,*add stitle sdescription scontent)
                            (define exists #f)


### PR DESCRIPTION
## Summary

- extend the teaching-language documentation DSL with optional single- or multi-block section descriptions
- preserve section descriptions when documentation is inherited or merged
- document Posns with an HtDP-style Data Definition and coordinate interpretation

## Why

The Beginner language Posns section jumps directly into procedure entries without first explaining what a Posn represents or how its coordinates correspond to a position. This adds a concise data definition aligned with the terminology and presentation used in HtDP.

## Validation

- loaded `htdp-lib/lang/private/beginner-funs.rkt` against this checkout with Racket 9.2
- rendered `htdp-doc/scribblings/htdp-langs/htdp-langs.scrbl` as multi-page HTML
- inspected the generated Beginner Posns section
- ran `git diff --check`